### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/workers/image-worker.js
+++ b/workers/image-worker.js
@@ -19,8 +19,8 @@ const hasValidToken = (request, env) => {
   const authHeader = request.headers.get("Authorization");
   const expectedToken = `Bearer ${env.API_TOKEN}`;
   console.log('Auth check:', {
-    received: authHeader,
-    expected: expectedToken
+    received: authHeader ? '[REDACTED]' : 'None',
+    match: authHeader === expectedToken
   });
   return authHeader === expectedToken;
 };


### PR DESCRIPTION
Potential fix for [https://github.com/StephenJLu/striae/security/code-scanning/1](https://github.com/StephenJLu/striae/security/code-scanning/1)

To fix the problem, we should avoid logging the value of `env.API_TOKEN` (or any derived value such as `expectedToken`). Instead, we can log only non-sensitive information, such as whether the received token matched the expected format, or simply that an authentication check occurred. Specifically, in the `hasValidToken` function, we should remove or redact the logging of the expected token. If logging is needed for debugging, we can log only the presence or absence of the Authorization header, or a boolean indicating whether the check passed, without exposing the actual token values.

The change should be made in `workers/image-worker.js`, specifically in the block starting at line 21. No new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
