### PR TITLE
fix earliest annotation type declaration box annotations

### DIFF
--- a/app/components/canvas/box-annotations/box-annotations.tsx
+++ b/app/components/canvas/box-annotations/box-annotations.tsx
@@ -30,8 +30,9 @@ interface BoxAnnotationsProps {
   className?: string;
   annotationData?: {
     additionalNotes?: string;
+    earliestAnnotationTimestamp?: string;
   };
-  onAnnotationDataChange?: (data: { additionalNotes?: string; boxAnnotations?: BoxAnnotation[] }) => void;
+  onAnnotationDataChange?: (data: { additionalNotes?: string; boxAnnotations?: BoxAnnotation[]; earliestAnnotationTimestamp?: string }) => void;
   isReadOnly?: boolean;
   caseNumber: string; // Required for audit logging
   imageFileId?: string;


### PR DESCRIPTION
This pull request introduces an update to the `BoxAnnotationsProps` interface in `box-annotations.tsx` to support tracking the earliest annotation timestamp. The change also ensures this new field is included in the annotation data change handler for consistency.

Annotation data enhancements:

* Added an optional `earliestAnnotationTimestamp` field to the `annotationData` object to enable tracking of the earliest annotation time.

Event handler update:

* Updated the `onAnnotationDataChange` callback signature to include `earliestAnnotationTimestamp`, ensuring any changes to annotation data can propagate this new field.