### PR TITLE
fix infinite re-render loops

### DIFF
--- a/app/components/sidebar/cases/cases-modal.tsx
+++ b/app/components/sidebar/cases/cases-modal.tsx
@@ -65,12 +65,17 @@ export const CasesModal = ({ isOpen, onClose, onSelectCase, currentCase, user }:
   // Fetch confirmation status only for currently visible paginated cases
   useEffect(() => {
     const fetchCaseConfirmationStatuses = async () => {
-      if (!isOpen || paginatedCases.length === 0) {
+      const visibleCases = cases.slice(
+        currentPage * CASES_PER_PAGE,
+        (currentPage + 1) * CASES_PER_PAGE
+      );
+
+      if (!isOpen || visibleCases.length === 0) {
         return;
       }
 
       // Fetch case statuses in parallel for only visible cases
-      const caseStatusPromises = paginatedCases.map(async (caseNum) => {
+      const caseStatusPromises = visibleCases.map(async (caseNum) => {
         try {
           const files = await fetchFiles(user, caseNum, { skipValidation: true });
           
@@ -124,7 +129,7 @@ export const CasesModal = ({ isOpen, onClose, onSelectCase, currentCase, user }:
     };
 
     fetchCaseConfirmationStatuses();
-  }, [isOpen, paginatedCases, user]);
+  }, [isOpen, currentPage, cases, user]);
 
   if (!isOpen) return null;
 

--- a/app/components/sidebar/files/files-modal.tsx
+++ b/app/components/sidebar/files/files-modal.tsx
@@ -41,12 +41,14 @@ export const FilesModal = ({ isOpen, onClose, onFileSelect, currentCase, files, 
   // Fetch confirmation status only for currently visible paginated files
   useEffect(() => {
     const fetchConfirmationStatuses = async () => {
-      if (!isOpen || !currentCase || !user || currentFiles.length === 0) {
+      const visibleFiles = files.slice(startIndex, endIndex);
+
+      if (!isOpen || !currentCase || !user || visibleFiles.length === 0) {
         return;
       }
 
       // Fetch annotations in parallel for only visible files
-      const annotationPromises = currentFiles.map(async (file) => {
+      const annotationPromises = visibleFiles.map(async (file) => {
         try {
           const annotations = await getFileAnnotations(user, currentCase, file.id);
           return {
@@ -80,7 +82,7 @@ export const FilesModal = ({ isOpen, onClose, onFileSelect, currentCase, files, 
     };
 
     fetchConfirmationStatuses();
-  }, [isOpen, currentCase, currentFiles, user]);
+  }, [isOpen, currentCase, currentPage, files, user]);
 
   const handleFileSelect = (file: FileData) => {
     onFileSelect?.(file);


### PR DESCRIPTION
This pull request updates the logic for fetching confirmation statuses in both the cases and files modals so that only the currently visible (paginated) items are processed. This improves performance and ensures that unnecessary data is not fetched for items not currently displayed.

**Pagination-aware data fetching:**

* In `cases-modal.tsx`, the confirmation status fetching logic now uses only the cases visible on the current page, rather than all paginated cases. The effect dependencies were updated to trigger correctly when the page or cases change. [[1]](diffhunk://#diff-9a811610589d8cf81cf68613c25833c44a93c457e1200a0195548bacdc8ea3f2L68-R78) [[2]](diffhunk://#diff-9a811610589d8cf81cf68613c25833c44a93c457e1200a0195548bacdc8ea3f2L127-R132)
* In `files-modal.tsx`, the confirmation status fetching logic now uses only the files visible on the current page, rather than all files. The effect dependencies were updated to trigger correctly when the page or files change. [[1]](diffhunk://#diff-ca2b6908355d7888b2994651a183727889c5c40a312c010df0650e3a743b59acL44-R51) [[2]](diffhunk://#diff-ca2b6908355d7888b2994651a183727889c5c40a312c010df0650e3a743b59acL83-R85)