### PR TITLE
fix files modal currentPage dep

### DIFF
--- a/app/components/sidebar/files/files-modal.tsx
+++ b/app/components/sidebar/files/files-modal.tsx
@@ -41,7 +41,7 @@ export const FilesModal = ({ isOpen, onClose, onFileSelect, currentCase, files, 
   // Fetch confirmation status only for currently visible paginated files
   useEffect(() => {
     const fetchConfirmationStatuses = async () => {
-      const visibleFiles = files.slice(startIndex, endIndex);
+      const visibleFiles = files.slice(currentPage * FILES_PER_PAGE, (currentPage + 1) * FILES_PER_PAGE);
 
       if (!isOpen || !currentCase || !user || visibleFiles.length === 0) {
         return;


### PR DESCRIPTION
This pull request makes a small update to the logic for fetching confirmation statuses in the `FilesModal` component. The change ensures that the correct set of files is selected for the current page by updating the slicing logic.

* Updated the calculation for `visibleFiles` in `files-modal.tsx` to use `currentPage` and `FILES_PER_PAGE` for accurate pagination.