### PR TITLE
rm redundancy

### DIFF
--- a/app/components/sidebar/files/files-modal.tsx
+++ b/app/components/sidebar/files/files-modal.tsx
@@ -41,7 +41,7 @@ export const FilesModal = ({ isOpen, onClose, onFileSelect, currentCase, files, 
   // Fetch confirmation status only for currently visible paginated files
   useEffect(() => {
     const fetchConfirmationStatuses = async () => {
-      const visibleFiles = files.slice(currentPage * FILES_PER_PAGE, (currentPage + 1) * FILES_PER_PAGE);
+      const visibleFiles = currentFiles;
 
       if (!isOpen || !currentCase || !user || visibleFiles.length === 0) {
         return;


### PR DESCRIPTION
This pull request makes a small update to the `FilesModal` component to improve how visible files are determined when fetching confirmation statuses. Instead of slicing the `files` array directly, the code now uses the `currentFiles` variable for clarity and correctness.

* Refactored the logic in `FilesModal` to use `currentFiles` instead of slicing `files` directly when fetching confirmation statuses, ensuring the correct set of files is considered.