### PR TITLE
separated meta config and app config concerns. upd deploy config scripts

### DIFF
--- a/app/config-example/config.json
+++ b/app/config-example/config.json
@@ -1,7 +1,4 @@
-{
-  "name": "Striae",  
-  "author": "Stephen J. Lu",
-  "title": "A Firearms Examiner's Comparison Companion",  
+{    
   "url": "PAGES_CUSTOM_DOMAIN",    
   "data_worker_url": "DATA_WORKER_CUSTOM_DOMAIN",
   "keys_url": "KEYS_WORKER_CUSTOM_DOMAIN",

--- a/app/config-example/meta-config.json
+++ b/app/config-example/meta-config.json
@@ -1,0 +1,6 @@
+{
+    "name": "Striae",  
+    "author": "Stephen J. Lu",
+    "title": "A Firearms Examiner's Comparison Companion",
+    "url": "PAGES_CUSTOM_DOMAIN"
+}

--- a/app/utils/meta.ts
+++ b/app/utils/meta.ts
@@ -1,4 +1,4 @@
-import config from '~/config/config.json';
+import config from '~/config/meta-config.json';
 
 interface AppConfig {
   name: string;

--- a/scripts/deploy-config.bat
+++ b/scripts/deploy-config.bat
@@ -816,6 +816,13 @@ if exist "app\config\config.json" (
     echo [92m      ✅ app config.json updated[0m
 )
 
+REM Update app/config/meta-config.json
+if exist "app\config\meta-config.json" (
+    echo [93m    Updating app/config/meta-config.json...[0m
+    powershell -Command "(Get-Content 'app/config/meta-config.json') -replace '\"PAGES_CUSTOM_DOMAIN\"', '\"https://%PAGES_CUSTOM_DOMAIN%\"' | Set-Content 'app/config/meta-config.json'"
+    echo [92m      ✅ app meta-config.json updated[0m
+)
+
 REM Update app/config/firebase.ts
 if exist "app\config\firebase.ts" (
     echo [93m    Updating app/config/firebase.ts...[0m

--- a/scripts/deploy-config.ps1
+++ b/scripts/deploy-config.ps1
@@ -486,6 +486,15 @@ function Update-WranglerConfigs {
         Write-Host "${Green}      ✅ app config.json updated${Reset}"
     }
     
+    # Update app/config/meta-config.json
+    if (Test-Path "app/config/meta-config.json") {
+        Write-Host "${Yellow}    Updating app/config/meta-config.json...${Reset}"
+        $content = Get-Content "app/config/meta-config.json" -Raw
+        $content = $content -replace '"PAGES_CUSTOM_DOMAIN"', "`"https://$PAGES_CUSTOM_DOMAIN`""
+        Set-Content -Path "app/config/meta-config.json" -Value $content -NoNewline
+        Write-Host "${Green}      ✅ app meta-config.json updated${Reset}"
+    }
+    
     # Update app/config/firebase.ts
     if (Test-Path "app/config/firebase.ts") {
         Write-Host "${Yellow}    Updating app/config/firebase.ts...${Reset}"

--- a/scripts/deploy-config.sh
+++ b/scripts/deploy-config.sh
@@ -488,6 +488,13 @@ update_wrangler_configs() {
         echo -e "${GREEN}      ✅ app config.json updated${NC}"
     fi
     
+    # Update app/config/meta-config.json
+    if [ -f "app/config/meta-config.json" ]; then
+        echo -e "${YELLOW}    Updating app/config/meta-config.json...${NC}"
+        sed -i "s|\"PAGES_CUSTOM_DOMAIN\"|\"https://$PAGES_CUSTOM_DOMAIN\"|g" app/config/meta-config.json
+        echo -e "${GREEN}      ✅ app meta-config.json updated${NC}"
+    fi
+    
     # Update app/config/firebase.ts
     if [ -f "app/config/firebase.ts" ]; then
         echo -e "${YELLOW}    Updating app/config/firebase.ts...${NC}"


### PR DESCRIPTION
This pull request introduces a new `meta-config.json` file to separate application metadata from other configuration values, updates relevant scripts to handle this new file, and adjusts imports to use the new metadata configuration. These changes help organize configuration files more cleanly and ensure deployment scripts correctly update both config files.

**Configuration file restructuring:**

* Created `app/config-example/meta-config.json` to store application metadata such as `name`, `author`, `title`, and `url`, separating it from the main `config.json`.
* Removed metadata fields from `app/config-example/config.json`, leaving only operational configuration values.

**Code updates for new config file:**

* Changed the import in `app/utils/meta.ts` to use `meta-config.json` instead of `config.json`, ensuring metadata is read from the new file.

**Deployment script enhancements:**

* Updated `scripts/deploy-config.bat`, `scripts/deploy-config.ps1`, and `scripts/deploy-config.sh` to add support for updating `app/config/meta-config.json` with the correct domain during deployment, mirroring the logic used for `config.json`. [[1]](diffhunk://#diff-1c98c9167309ff9daaece2ed0593f090110f211e5695ca06f743ef237381d0bdR819-R825) [[2]](diffhunk://#diff-5c37dd09c44dbb634c35d1aeb47a947490c3735d2a1dc0b4580e97a763254b58R489-R497) [[3]](diffhunk://#diff-e128c6dc9fff6dbba29276fd335fbfd22f10e80b80a0f18ad21f965457e60193R491-R497)