### PR TITLE
fix secret generation and replacement scripts

### DIFF
--- a/scripts/deploy-config.bat
+++ b/scripts/deploy-config.bat
@@ -361,33 +361,83 @@ if not "%SL_API_KEY%"=="" (
 
 echo [94mUSER_DB_AUTH[0m
 echo [93mCustom user database authentication token (generate with: openssl rand -hex 16)[0m
-echo [95mAuto-generating secret...[0m
-for /f %%i in ('openssl rand -hex 32 2^>nul ^|^| powershell -Command "[System.Web.Security.Membership]::GeneratePassword(64, 0) -replace '[^a-f0-9]', '' | ForEach-Object { $_.Substring(0, [Math]::Min(64, $_.Length)) }"') do set "USER_DB_AUTH=%%i"
-if not "%USER_DB_AUTH%"=="" (
-    powershell -Command "(Get-Content '.env') -replace '^USER_DB_AUTH=.*', 'USER_DB_AUTH=%USER_DB_AUTH%' | Set-Content '.env'"
-    echo [92m✅ USER_DB_AUTH auto-generated[0m
-) else (
-    echo [91m❌ Failed to auto-generate, please enter manually:[0m
-    set /p "USER_DB_AUTH=Enter value: "
+
+REM Check if USER_DB_AUTH already exists in .env and is not a placeholder
+if "%USER_DB_AUTH%"=="" (
+    echo [95mAuto-generating secret...[0m
+    for /f %%i in ('openssl rand -hex 32 2^>nul ^|^| powershell -Command "[System.Web.Security.Membership]::GeneratePassword(64, 0) -replace '[^a-f0-9]', '' | ForEach-Object { $_.Substring(0, [Math]::Min(64, $_.Length)) }"') do set "USER_DB_AUTH=%%i"
     if not "%USER_DB_AUTH%"=="" (
         powershell -Command "(Get-Content '.env') -replace '^USER_DB_AUTH=.*', 'USER_DB_AUTH=%USER_DB_AUTH%' | Set-Content '.env'"
-        echo [92m✅ USER_DB_AUTH updated[0m
+        echo [92m✅ USER_DB_AUTH auto-generated[0m
+    ) else (
+        echo [91m❌ Failed to auto-generate, please enter manually:[0m
+        set /p "USER_DB_AUTH=Enter value: "
+        if not "%USER_DB_AUTH%"=="" (
+            powershell -Command "(Get-Content '.env') -replace '^USER_DB_AUTH=.*', 'USER_DB_AUTH=%USER_DB_AUTH%' | Set-Content '.env'"
+            echo [92m✅ USER_DB_AUTH updated[0m
+        )
+    )
+) else (
+    REM Current value exists
+    echo [92mCurrent value: [HIDDEN][0m
+    set /p "USER_DB_AUTH_CHOICE=Generate new secret? (press Enter to keep current, or type 'y' to generate): "
+    if /i "%USER_DB_AUTH_CHOICE%"=="y" (
+        echo [95mAuto-generating secret...[0m
+        for /f %%i in ('openssl rand -hex 32 2^>nul ^|^| powershell -Command "[System.Web.Security.Membership]::GeneratePassword(64, 0) -replace '[^a-f0-9]', '' | ForEach-Object { $_.Substring(0, [Math]::Min(64, $_.Length)) }"') do set "USER_DB_AUTH=%%i"
+        if not "%USER_DB_AUTH%"=="" (
+            powershell -Command "(Get-Content '.env') -replace '^USER_DB_AUTH=.*', 'USER_DB_AUTH=%USER_DB_AUTH%' | Set-Content '.env'"
+            echo [92m✅ USER_DB_AUTH auto-generated[0m
+        ) else (
+            echo [91m❌ Failed to auto-generate, please enter manually:[0m
+            set /p "USER_DB_AUTH=Enter value: "
+            if not "%USER_DB_AUTH%"=="" (
+                powershell -Command "(Get-Content '.env') -replace '^USER_DB_AUTH=.*', 'USER_DB_AUTH=%USER_DB_AUTH%' | Set-Content '.env'"
+                echo [92m✅ USER_DB_AUTH updated[0m
+            )
+        )
+    ) else (
+        echo [92m✅ Keeping current value for USER_DB_AUTH[0m
     )
 )
 
 echo [94mR2_KEY_SECRET[0m
 echo [93mCustom R2 storage authentication token (generate with: openssl rand -hex 16)[0m
-echo [95mAuto-generating secret...[0m
-for /f %%i in ('openssl rand -hex 32 2^>nul ^|^| powershell -Command "[System.Web.Security.Membership]::GeneratePassword(64, 0) -replace '[^a-f0-9]', '' | ForEach-Object { $_.Substring(0, [Math]::Min(64, $_.Length)) }"') do set "R2_KEY_SECRET=%%i"
-if not "%R2_KEY_SECRET%"=="" (
-    powershell -Command "(Get-Content '.env') -replace '^R2_KEY_SECRET=.*', 'R2_KEY_SECRET=%R2_KEY_SECRET%' | Set-Content '.env'"
-    echo [92m✅ R2_KEY_SECRET auto-generated[0m
-) else (
-    echo [91m❌ Failed to auto-generate, please enter manually:[0m
-    set /p "R2_KEY_SECRET=Enter value: "
+
+REM Check if R2_KEY_SECRET already exists in .env and is not a placeholder
+if "%R2_KEY_SECRET%"=="" (
+    echo [95mAuto-generating secret...[0m
+    for /f %%i in ('openssl rand -hex 32 2^>nul ^|^| powershell -Command "[System.Web.Security.Membership]::GeneratePassword(64, 0) -replace '[^a-f0-9]', '' | ForEach-Object { $_.Substring(0, [Math]::Min(64, $_.Length)) }"') do set "R2_KEY_SECRET=%%i"
     if not "%R2_KEY_SECRET%"=="" (
         powershell -Command "(Get-Content '.env') -replace '^R2_KEY_SECRET=.*', 'R2_KEY_SECRET=%R2_KEY_SECRET%' | Set-Content '.env'"
-        echo [92m✅ R2_KEY_SECRET updated[0m
+        echo [92m✅ R2_KEY_SECRET auto-generated[0m
+    ) else (
+        echo [91m❌ Failed to auto-generate, please enter manually:[0m
+        set /p "R2_KEY_SECRET=Enter value: "
+        if not "%R2_KEY_SECRET%"=="" (
+            powershell -Command "(Get-Content '.env') -replace '^R2_KEY_SECRET=.*', 'R2_KEY_SECRET=%R2_KEY_SECRET%' | Set-Content '.env'"
+            echo [92m✅ R2_KEY_SECRET updated[0m
+        )
+    )
+) else (
+    REM Current value exists
+    echo [92mCurrent value: [HIDDEN][0m
+    set /p "R2_KEY_SECRET_CHOICE=Generate new secret? (press Enter to keep current, or type 'y' to generate): "
+    if /i "%R2_KEY_SECRET_CHOICE%"=="y" (
+        echo [95mAuto-generating secret...[0m
+        for /f %%i in ('openssl rand -hex 32 2^>nul ^|^| powershell -Command "[System.Web.Security.Membership]::GeneratePassword(64, 0) -replace '[^a-f0-9]', '' | ForEach-Object { $_.Substring(0, [Math]::Min(64, $_.Length)) }"') do set "R2_KEY_SECRET=%%i"
+        if not "%R2_KEY_SECRET%"=="" (
+            powershell -Command "(Get-Content '.env') -replace '^R2_KEY_SECRET=.*', 'R2_KEY_SECRET=%R2_KEY_SECRET%' | Set-Content '.env'"
+            echo [92m✅ R2_KEY_SECRET auto-generated[0m
+        ) else (
+            echo [91m❌ Failed to auto-generate, please enter manually:[0m
+            set /p "R2_KEY_SECRET=Enter value: "
+            if not "%R2_KEY_SECRET%"=="" (
+                powershell -Command "(Get-Content '.env') -replace '^R2_KEY_SECRET=.*', 'R2_KEY_SECRET=%R2_KEY_SECRET%' | Set-Content '.env'"
+                echo [92m✅ R2_KEY_SECRET updated[0m
+            )
+        )
+    ) else (
+        echo [92m✅ Keeping current value for R2_KEY_SECRET[0m
     )
 )
 
@@ -626,17 +676,42 @@ echo [94m🔐 SERVICE-SPECIFIC SECRETS[0m
 echo ============================
 echo [94mKEYS_AUTH[0m
 echo [93mKeys worker authentication token (generate with: openssl rand -hex 16)[0m
-echo [95mAuto-generating secret...[0m
-for /f %%i in ('openssl rand -hex 32 2^>nul ^|^| powershell -Command "[System.Web.Security.Membership]::GeneratePassword(64, 0) -replace '[^a-f0-9]', '' | ForEach-Object { $_.Substring(0, [Math]::Min(64, $_.Length)) }"') do set "KEYS_AUTH=%%i"
-if not "%KEYS_AUTH%"=="" (
-    powershell -Command "(Get-Content '.env') -replace '^KEYS_AUTH=.*', 'KEYS_AUTH=%KEYS_AUTH%' | Set-Content '.env'"
-    echo [92m✅ KEYS_AUTH auto-generated[0m
-) else (
-    echo [91m❌ Failed to auto-generate, please enter manually:[0m
-    set /p "KEYS_AUTH=Enter value: "
+
+REM Check if KEYS_AUTH already exists in .env and is not a placeholder
+if "%KEYS_AUTH%"=="" (
+    echo [95mAuto-generating secret...[0m
+    for /f %%i in ('openssl rand -hex 32 2^>nul ^|^| powershell -Command "[System.Web.Security.Membership]::GeneratePassword(64, 0) -replace '[^a-f0-9]', '' | ForEach-Object { $_.Substring(0, [Math]::Min(64, $_.Length)) }"') do set "KEYS_AUTH=%%i"
     if not "%KEYS_AUTH%"=="" (
         powershell -Command "(Get-Content '.env') -replace '^KEYS_AUTH=.*', 'KEYS_AUTH=%KEYS_AUTH%' | Set-Content '.env'"
-        echo [92m✅ KEYS_AUTH updated[0m
+        echo [92m✅ KEYS_AUTH auto-generated[0m
+    ) else (
+        echo [91m❌ Failed to auto-generate, please enter manually:[0m
+        set /p "KEYS_AUTH=Enter value: "
+        if not "%KEYS_AUTH%"=="" (
+            powershell -Command "(Get-Content '.env') -replace '^KEYS_AUTH=.*', 'KEYS_AUTH=%KEYS_AUTH%' | Set-Content '.env'"
+            echo [92m✅ KEYS_AUTH updated[0m
+        )
+    )
+) else (
+    REM Current value exists
+    echo [92mCurrent value: [HIDDEN][0m
+    set /p "KEYS_AUTH_CHOICE=Generate new secret? (press Enter to keep current, or type 'y' to generate): "
+    if /i "%KEYS_AUTH_CHOICE%"=="y" (
+        echo [95mAuto-generating secret...[0m
+        for /f %%i in ('openssl rand -hex 32 2^>nul ^|^| powershell -Command "[System.Web.Security.Membership]::GeneratePassword(64, 0) -replace '[^a-f0-9]', '' | ForEach-Object { $_.Substring(0, [Math]::Min(64, $_.Length)) }"') do set "KEYS_AUTH=%%i"
+        if not "%KEYS_AUTH%"=="" (
+            powershell -Command "(Get-Content '.env') -replace '^KEYS_AUTH=.*', 'KEYS_AUTH=%KEYS_AUTH%' | Set-Content '.env'"
+            echo [92m✅ KEYS_AUTH auto-generated[0m
+        ) else (
+            echo [91m❌ Failed to auto-generate, please enter manually:[0m
+            set /p "KEYS_AUTH=Enter value: "
+            if not "%KEYS_AUTH%"=="" (
+                powershell -Command "(Get-Content '.env') -replace '^KEYS_AUTH=.*', 'KEYS_AUTH=%KEYS_AUTH%' | Set-Content '.env'"
+                echo [92m✅ KEYS_AUTH updated[0m
+            )
+        )
+    ) else (
+        echo [92m✅ Keeping current value for KEYS_AUTH[0m
     )
 )
 

--- a/scripts/deploy-config.sh
+++ b/scripts/deploy-config.sh
@@ -227,26 +227,40 @@ prompt_for_secrets() {
         local var_name=$1
         local description=$2
         local current_value="${!var_name}"
+        local new_value=""
         
-        # Auto-generate specific authentication secrets
+        # Auto-generate specific authentication secrets - but allow keeping current
         if [ "$var_name" = "USER_DB_AUTH" ] || [ "$var_name" = "R2_KEY_SECRET" ] || [ "$var_name" = "KEYS_AUTH" ]; then
             echo -e "${BLUE}$var_name${NC}"
             echo -e "${YELLOW}$description${NC}"
             
             if [ -n "$current_value" ] && [ "$current_value" != "your_${var_name,,}_here" ] && [ "$current_value" != "your_custom_user_db_auth_token_here" ] && [ "$current_value" != "your_custom_r2_secret_here" ] && [ "$current_value" != "your_custom_keys_auth_token_here" ]; then
+                # Current value exists and is not a placeholder
                 echo -e "${GREEN}Current value: [HIDDEN]${NC}"
-                echo -e "${YELLOW}Auto-generating new secret...${NC}"
+                read -p "Generate new secret? (press Enter to keep current, or type 'y' to generate): " gen_choice
+                
+                if [ "$gen_choice" = "y" ] || [ "$gen_choice" = "Y" ]; then
+                    new_value=$(openssl rand -hex 32 2>/dev/null || echo "")
+                    if [ -n "$new_value" ]; then
+                        echo -e "${GREEN}✅ $var_name auto-generated${NC}"
+                    else
+                        echo -e "${RED}❌ Failed to auto-generate, please enter manually:${NC}"
+                        read -p "Enter value: " new_value
+                    fi
+                else
+                    # User wants to keep current value
+                    new_value=""
+                fi
             else
+                # No current value or placeholder value - auto-generate
                 echo -e "${YELLOW}Auto-generating secret...${NC}"
-            fi
-            
-            # Generate new secret using openssl
-            new_value=$(openssl rand -hex 32 2>/dev/null || echo "")
-            if [ -n "$new_value" ]; then
-                echo -e "${GREEN}✅ $var_name auto-generated${NC}"
-            else
-                echo -e "${RED}❌ Failed to auto-generate, please enter manually:${NC}"
-                read -p "Enter value: " new_value
+                new_value=$(openssl rand -hex 32 2>/dev/null || echo "")
+                if [ -n "$new_value" ]; then
+                    echo -e "${GREEN}✅ $var_name auto-generated${NC}"
+                else
+                    echo -e "${RED}❌ Failed to auto-generate, please enter manually:${NC}"
+                    read -p "Enter value: " new_value
+                fi
             fi
         else
             # Normal prompt for other variables


### PR DESCRIPTION
This pull request updates the secret generation logic in deployment scripts (`deploy-config.bat`, `deploy-config.sh`, and `deploy-config.ps1`) to give users the option to keep existing secrets or generate new ones for key authentication variables. This improves usability and prevents accidental overwrites of existing secrets.

Secret management improvements:

* Added checks for existing values of `USER_DB_AUTH`, `R2_KEY_SECRET`, and `KEYS_AUTH` in `.env`. If a value already exists and is not a placeholder, the scripts now prompt the user to either keep the current value or generate a new secret. [[1]](diffhunk://#diff-1c98c9167309ff9daaece2ed0593f090110f211e5695ca06f743ef237381d0bdR364-R366) [[2]](diffhunk://#diff-1c98c9167309ff9daaece2ed0593f090110f211e5695ca06f743ef237381d0bdR380-R407) [[3]](diffhunk://#diff-1c98c9167309ff9daaece2ed0593f090110f211e5695ca06f743ef237381d0bdR421-R442) [[4]](diffhunk://#diff-1c98c9167309ff9daaece2ed0593f090110f211e5695ca06f743ef237381d0bdR679-R699) [[5]](diffhunk://#diff-1c98c9167309ff9daaece2ed0593f090110f211e5695ca06f743ef237381d0bdR713-R716)
* Updated the logic in `deploy-config.ps1` and `deploy-config.sh` to match the new behavior, including user prompts and fallback handling for secret generation failures. [[1]](diffhunk://#diff-5c37dd09c44dbb634c35d1aeb47a947490c3735d2a1dc0b4580e97a763254b58R180-R212) [[2]](diffhunk://#diff-5c37dd09c44dbb634c35d1aeb47a947490c3735d2a1dc0b4580e97a763254b58R226) [[3]](diffhunk://#diff-e128c6dc9fff6dbba29276fd335fbfd22f10e80b80a0f18ad21f965457e60193R230-R264)

User experience enhancements:

* When keeping the current value, scripts display a confirmation message and hide the actual secret for security. [[1]](diffhunk://#diff-1c98c9167309ff9daaece2ed0593f090110f211e5695ca06f743ef237381d0bdR380-R407) [[2]](diffhunk://#diff-1c98c9167309ff9daaece2ed0593f090110f211e5695ca06f743ef237381d0bdR421-R442) [[3]](diffhunk://#diff-1c98c9167309ff9daaece2ed0593f090110f211e5695ca06f743ef237381d0bdR713-R716)
* Improved fallback handling: if auto-generation fails, users are prompted to enter a value manually. [[1]](diffhunk://#diff-5c37dd09c44dbb634c35d1aeb47a947490c3735d2a1dc0b4580e97a763254b58R180-R212) [[2]](diffhunk://#diff-e128c6dc9fff6dbba29276fd335fbfd22f10e80b80a0f18ad21f965457e60193R230-R264)