### PR TITLE
enable worker traces

### DIFF
--- a/workers/audit-worker/wrangler.jsonc.example
+++ b/workers/audit-worker/wrangler.jsonc.example
@@ -8,7 +8,10 @@
   ], 
   
   "observability": { 
-	"enabled": true
+	"enabled": true,
+  "traces": {
+      "enabled": true
+    }
   },
 
   "r2_buckets": [

--- a/workers/data-worker/wrangler.jsonc.example
+++ b/workers/data-worker/wrangler.jsonc.example
@@ -8,7 +8,10 @@
   ], 
   
   "observability": { 
-	"enabled": true
+	"enabled": true,
+  "traces": {
+      "enabled": true
+    }
   },
 
   "r2_buckets": [

--- a/workers/image-worker/wrangler.jsonc.example
+++ b/workers/image-worker/wrangler.jsonc.example
@@ -8,7 +8,10 @@
   ], 
   
   "observability": { 
-	"enabled": true
+	"enabled": true,
+  "traces": {
+      "enabled": true
+    }
   },
   
   "routes": [

--- a/workers/keys-worker/wrangler.jsonc.example
+++ b/workers/keys-worker/wrangler.jsonc.example
@@ -8,7 +8,10 @@
   ], 
   
   "observability": { 
-	"enabled": true
+	"enabled": true,
+  "traces": {
+      "enabled": true
+    }
   },  
 
   "routes": [

--- a/workers/pdf-worker/wrangler.jsonc.example
+++ b/workers/pdf-worker/wrangler.jsonc.example
@@ -6,11 +6,16 @@
   "compatibility_flags": [
     "nodejs_compat"
   ],
+  
   "browser": {
     "binding": "BROWSER"
   },
+  
   "observability": { 
-	"enabled": true
+	"enabled": true,
+  "traces": {
+      "enabled": true
+    }
   },
 
   "routes": [

--- a/workers/turnstile-worker/wrangler.jsonc.example
+++ b/workers/turnstile-worker/wrangler.jsonc.example
@@ -5,15 +5,21 @@
   "compatibility_date": "2023-03-14",
   "compatibility_flags": [
     "nodejs_compat"
-  ],  
+  ],
+
   "observability": { 
-	"enabled": true
+	"enabled": true,
+  "traces": {
+      "enabled": true
+    }
   },
+
   "routes": [
     {
       "pattern": "TURNSTILE_WORKER_DOMAIN",
       "custom_domain": true
     }
   ],
+
   "placement": { "mode": "smart" }
 }

--- a/workers/user-worker/wrangler.jsonc.example
+++ b/workers/user-worker/wrangler.jsonc.example
@@ -8,7 +8,10 @@
   ], 
   
   "observability": { 
-	"enabled": true
+	"enabled": true,
+  "traces": {
+      "enabled": true
+    }
   },
 
    "kv_namespaces": [


### PR DESCRIPTION
This pull request updates the example configuration files for several workers to enable observability and tracing features. The main change is the addition of an `observability` section with tracing enabled in each worker's `wrangler.jsonc.example` file. This improves monitoring and debugging capabilities across the worker services.

Observability enhancements:

* Added `"observability"` configuration with `"enabled": true` and enabled `"traces"` for the following workers: `audit-worker`, `data-worker`, `image-worker`, `keys-worker`, `pdf-worker`, `turnstile-worker`, and `user-worker` in their respective `wrangler.jsonc.example` files. [[1]](diffhunk://#diff-1a6087ffb2a3e27bd4d44cde8f8c758f6898e55de22ae50959d430ffb241bb5dR11-R14) [[2]](diffhunk://#diff-a06bd34d808c6d17bced83f7809fdc3cc67dbd9e9660d6fca84465f89b3c3d28R11-R14) [[3]](diffhunk://#diff-e1d3129c96b6720c42ba1122071136b06284163dfb6f166c78e23c298d5ab0a1R11-R14) [[4]](diffhunk://#diff-8b381e5cbe2ecf42b3c7897439b111279472a8170b7bc52aac0760f0b7829fa7R11-R14) [[5]](diffhunk://#diff-4645a382213755d06092c726a199073136b1ffd843a8581bb127b509e90783b9R9-R18) [[6]](diffhunk://#diff-b72f0792ceeda377d6c18c2afaec888dd100e7e0d06a41a78cfd346ee60254c7R9-R23) [[7]](diffhunk://#diff-2f63fd80985909733991b5f726934a04b6247e849aab2946763e8d1b55eba4ebR11-R14)