### PR TITLE
fix deploy-config.bat

### DIFF
--- a/scripts/deploy-config.bat
+++ b/scripts/deploy-config.bat
@@ -245,6 +245,16 @@ if not exist ".env" (
     echo [92m📄 Created .env from .env.example[0m
 )
 
+REM Load existing .env values into batch variables so prompt_required can show current values
+if exist ".env" (
+    for /f "tokens=1,2 delims==" %%A in (.env) do (
+        if not "%%A"=="" if not "%%A:~0,1%"=="#" (
+            set "%%A=%%B"
+        )
+    )
+    echo [92m✅ Loaded existing environment variables[0m
+)
+
 REM Always prompt for secrets configuration
 :prompt_secrets
 echo.


### PR DESCRIPTION
This pull request adds a helpful enhancement to the `scripts/deploy-config.bat` script. Now, when an existing `.env` file is present, the script loads its environment variable values into batch variables, allowing the prompts to display current values for easier editing and review.

Improvements to environment variable handling:

* Loads existing `.env` values into batch variables so that prompts can show the current values, making it easier for users to review and update environment variables during deployment.