### PR TITLE
clarify pgp key usage

### DIFF
--- a/app/routes/security/policy.tsx
+++ b/app/routes/security/policy.tsx
@@ -29,9 +29,9 @@ export const Policy = () => {
           <p>You may:
             <ol>
               <li>Email security findings to: <a href="mailto:info@striae.org">info@striae.org</a></li>
-              <li>Submit a security issue on <a href="https://github.com/striae-org/striae/security/advisories/new" target="_blank" rel="noopener noreferrer">GitHub</a></li>              
-            </ol>
-            For encryption, please use our <a href="https://keybase.io/stephenjlu/pgp_keys.asc" target="_blank" rel="noopener noreferrer">PGP key</a>
+              <li>Submit a security issue on <a href="https://github.com/striae-org/striae/security/advisories/new" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+              <li>Send Stephen an encrypted message using his <a href="https://keybase.io/stephenjlu/pgp_keys.asc" target="_blank" rel="noopener noreferrer">PGP key</a></li>
+            </ol>            
           </p>
         </section>
 


### PR DESCRIPTION
This pull request updates the security policy page to clarify how users can report security issues and use encryption. The main change is restructuring the instructions to make encrypted contact via PGP clearer and more actionable.

Improvements to security reporting instructions:

* Added a new list item instructing users to send Stephen an encrypted message using his PGP key, making the encryption option more prominent and actionable.
* Removed the previous standalone sentence about using the PGP key for encryption, consolidating all contact options into a clear, ordered list.