### PR TITLE
Dev

### DIFF
--- a/app/components/sidebar/case-import/case-import.module.css
+++ b/app/components/sidebar/case-import/case-import.module.css
@@ -192,6 +192,12 @@
   background: color-mix(in lab, var(--primary) 10%, transparent);
 }
 
+.fileLabel:focus-visible {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px color-mix(in lab, var(--primary) 20%, transparent);
+}
+
 .fileLabelDragOver {
   border-color: var(--accent) !important;
   background: color-mix(in lab, var(--accent) 15%, transparent) !important;

--- a/app/components/sidebar/case-import/case-import.tsx
+++ b/app/components/sidebar/case-import/case-import.tsx
@@ -262,7 +262,7 @@ export const CaseImport = ({
       <div className={styles.overlay} onClick={handleOverlayClick}>
       <div className={styles.modal}>
         <div className={styles.header}>
-          <h2 className={styles.title}>Import Case for Review</h2>
+          <h2 className={styles.title}>Import RO Case or Confirmations</h2>
           <button 
             className={styles.closeButton}
             onClick={onClose}
@@ -371,12 +371,20 @@ export const CaseImport = ({
 
             {/* Instructions */}
             <div className={styles.instructions}>
-              <h3 className={styles.instructionsTitle}>Instructions:</h3>
+              <h3 className={styles.instructionsTitle}>Case Review Instructions:</h3>
               <ul className={styles.instructionsList}>
                 <li>Only ZIP files (.zip) exported with the JSON data format from Striae are accepted</li>
                 <li>Only one case can be reviewed at a time</li>
                 <li>Imported cases are read-only and cannot be modified</li>
                 <li>Importing will automatically replace any existing review case</li>
+              </ul>
+              <br />
+              <h3 className={styles.instructionsTitle}>Confirmation Import Instructions:</h3>
+              <ul className={styles.instructionsList}>
+                <li>Only JSON files (.json) exported with confirmation data exported from Striae are accepted</li>
+                <li>Only one confirmation file can be imported at a time</li>
+                <li>Confirmed images will become read-only and cannot be modified</li>
+                <li>If an image has a pre-existing confirmation, it will be skipped</li>
               </ul>
             </div>
           </div>

--- a/app/components/sidebar/case-import/components/FileSelector.tsx
+++ b/app/components/sidebar/case-import/components/FileSelector.tsx
@@ -96,39 +96,42 @@ export const FileSelector = ({
           onChange={onFileSelect}
           disabled={isDisabled}
           className={styles.fileInput}
+          aria-label="File picker for ZIP or JSON files"
         />
         <div 
           className={`${styles.fileLabel} ${isDragOver ? styles.fileLabelDragOver : ''}`}
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
-        >
-          <label 
-            htmlFor="zipFile" 
-            className={styles.fileLabelContent}
-            role="button"
-            tabIndex={isDisabled ? -1 : 0}
-            aria-disabled={isDisabled}
-            aria-label="File selection area. Drag and drop a ZIP file for case import or JSON file for confirmation import."
-            onKeyDown={(e) => {
-              if ((e.key === 'Enter' || e.key === ' ') && !isDisabled) {
-                if (e.key === ' ') {
-                  e.preventDefault();
-                }
-                fileInputRef.current?.click();
+          onClick={() => {
+            if (!isDisabled) {
+              fileInputRef.current?.click();
+            }
+          }}
+          role="button"
+          tabIndex={isDisabled ? -1 : 0}
+          aria-disabled={isDisabled}
+          aria-label="File selection area. Drag and drop a ZIP file for case import or JSON file for confirmation import."
+          onKeyDown={(e) => {
+            if ((e.key === 'Enter' || e.key === ' ') && !isDisabled) {
+              if (e.key === ' ') {
+                e.preventDefault();
               }
-            }}
-          >
+              fileInputRef.current?.click();
+            }
+          }}
+        >
+          <div className={styles.fileLabelContent}>
             <span className={styles.fileLabelIcon}>📁</span>
             <span className={styles.fileLabelText}>
               {selectedFile 
                 ? selectedFile.name 
                 : isDragOver 
                   ? 'Drop file here...' 
-                  : 'Select ZIP file or JSON file... or drag & drop'
+                  : 'Select ZIP or JSON file... or drag & drop'
               }
             </span>
-          </label>
+          </div>
         </div>
         
         {/* Clear button positioned in upper right corner */}


### PR DESCRIPTION
This pull request updates the case import UI to clarify support for both RO case and confirmation imports, improves accessibility, and enhances the file selection experience. The most important changes are:

**UI/UX Improvements:**

* Updated the modal title to "Import RO Case or Confirmations" to clarify the types of imports supported.
* Expanded and clarified instructions, separating "Case Review Instructions" and new "Confirmation Import Instructions" to guide users on importing both ZIP (case) and JSON (confirmation) files.

**Accessibility and Interaction Enhancements:**

* Added an `aria-label` to the file input for better accessibility, specifying it is for ZIP or JSON files.
* Improved keyboard focus styling for the file label (`.fileLabel:focus-visible`), making it clearer when the label is focused.

**File Selector Improvements:**

* Changed the file label from a `<label>` to a `<div>` for better structure, and updated the placeholder text to "Select ZIP or JSON file... or drag & drop" for clarity.