### PR TITLE
add current case # to files modal title

### DIFF
--- a/app/components/sidebar/files/files-modal.tsx
+++ b/app/components/sidebar/files/files-modal.tsx
@@ -156,7 +156,7 @@ export const FilesModal = ({ isOpen, onClose, onFileSelect, currentCase, files, 
     <div className={styles.modalOverlay} onKeyDown={handleKeyDown} tabIndex={-1}>
       <div className={styles.modal}>
         <div className={styles.modalHeader}>
-          <h2>Files in Case</h2>
+          <h2>Files in Case {currentCase}</h2>
           <button
             className={styles.closeButton}
             onClick={onClose}


### PR DESCRIPTION
This pull request makes a small UI improvement to the files modal. The modal header now displays the current case identifier, making it easier for users to see which case's files they are viewing.

- [`app/components/sidebar/files/files-modal.tsx`](diffhunk://#diff-ca2b6908355d7888b2994651a183727889c5c40a312c010df0650e3a743b59acL159-R159): Updated the modal header to include the `currentCase` value in the title.