### PR TITLE
add demo account request forms

### DIFF
--- a/app/routes/access/NoticeText.tsx
+++ b/app/routes/access/NoticeText.tsx
@@ -30,8 +30,13 @@ export default function NoticeText() {
 
 <p>By registering, you&apos;re helping to build the future of Striae and digital annotation tools for forensic firearms examination. We can&apos;t wait to hear your insights and how you use it in your work!</p>
 
+<h2>Request a Demo Account</h2>
+<p>If you'd like to trial all of Striae's features before registering your agency, please <a href="https://support.striae.org/form/Y4sWjhi6Ppf" target="_blank" rel="noopener noreferrer">submit a request</a>.</p>
+<p>Demo accounts are created in the development instance of Striae and provide full access to all features for evaluation purposes only. Actual casework images and data, research data, or training materials should <em>NOT</em> be uploaded or entered using a demo account. <em>Demo account files and data may be subject to regular purging without notification.</em></p>
+<p>The creation of a demo account is subject to approval.</p>
+
 <h2>Custom Deployment Assistance</h2>
-<p>If your organization requires a custom deployment of Striae, we offer deployment assistance to meet your specific needs. Please <a href="https://support.striae.org/form/WA12nQGh9pS" target="_blank" rel="noopener noreferrer">click here</a> to submit a request.</p>
+<p>If your organization requires a custom deployment of Striae, we offer deployment assistance to meet your specific needs. <a href="https://support.striae.org/form/WA12nQGh9pS" target="_blank" rel="noopener noreferrer">Please click here to submit a request</a>.</p>
 
 </>
   );

--- a/app/routes/home/home.tsx
+++ b/app/routes/home/home.tsx
@@ -31,7 +31,7 @@ export default function Home() {
           </div>
           <div className={styles.buttonGroup}>            
             <a 
-              href="https://www.striae.org/auth"
+              href="/auth"
               target="_blank"
               rel="noopener noreferrer"
               className={styles.signInButton}>


### PR DESCRIPTION
This pull request updates user-facing content and improves the user experience on the registration and home pages. The main changes include adding information about requesting a demo account and updating the sign-in link for better navigation.

**User Experience Improvements:**

* Added a new "Request a Demo Account" section to `NoticeText`, providing users with information and a link to request demo access, as well as guidelines and limitations for demo accounts.
* Updated the "Custom Deployment Assistance" section in `NoticeText` to improve clarity and link text.

**Navigation Fix:**

* Changed the sign-in link in the home page (`home.tsx`) from an external URL to a relative internal route (`/auth`), which should provide a smoother user experience.