### PR TITLE
upd sitemap

### DIFF
--- a/app/routes/sitemap[.]xml.tsx
+++ b/app/routes/sitemap[.]xml.tsx
@@ -32,7 +32,10 @@ export const loader: LoaderFunction = async ({ context }) => {
     
     // User guides - Getting Started
     { path: "/guides/users/getting-started/striae-a-firearms-examiners-comparison-companion.md", changefreq: "monthly", priority: 0.8 },
+    { path: "/guides/users/getting-started/where-does-striae-fit.md", changefreq: "monthly", priority: 0.7 },
     { path: "/guides/users/getting-started/how-to-log-into-striae.md", changefreq: "monthly", priority: 0.7 },
+    { path: "/guides/users/getting-started/accessing-striae-registration-and-login.md", changefreq: "monthly", priority: 0.7 },
+    { path: "/guides/users/getting-started/authenticating-with-cloudflare-warp.md", changefreq: "monthly", priority: 0.7 },
     { path: "/guides/users/getting-started/code-of-responsible-use.md", changefreq: "yearly", priority: 0.6 },
     
     // User guides - Case Management
@@ -43,15 +46,16 @@ export const loader: LoaderFunction = async ({ context }) => {
     { path: "/guides/users/annotating-printing/box-annotations.md", changefreq: "monthly", priority: 0.6 },
     
     // User guides - Confirmations
-    { path: "/guides/users/confirmations/confirmations-guide.md", changefreq: "monthly", priority: 0.6 },
+    { path: "/guides/users/authenticated-confirmations/authenticated-confirmations.md", changefreq: "monthly", priority: 0.6 },
     
     // User guides - Audit Trail
-    { path: "/guides/users/audit-trail/audit-trail-user-guide.md", changefreq: "monthly", priority: 0.6 },
+    { path: "/guides/users/audit-trail-system/audit-trail-system.md", changefreq: "monthly", priority: 0.6 },
     
     // User guides - FAQs
     { path: "/guides/users/faqs/striae-frequently-asked-questions.md", changefreq: "monthly", priority: 0.6 },
     
     // Release notes - Stable
+    { path: "/release-notes/RELEASE_NOTES_v1.1.2.md", changefreq: "monthly", priority: 0.5 },
     { path: "/release-notes/RELEASE_NOTES_v1.1.1.md", changefreq: "monthly", priority: 0.5 },
     { path: "/release-notes/RELEASE_NOTES_v1.1.0.md", changefreq: "monthly", priority: 0.5 },
     { path: "/release-notes/RELEASE_NOTES_v1.0.5.md", changefreq: "monthly", priority: 0.5 },


### PR DESCRIPTION
This pull request updates the sitemap generation logic in `app/routes/sitemap.xml.tsx` to include new user guide pages, reorganize existing guide paths, and add the latest release notes. These changes ensure that the sitemap reflects the most current documentation structure and content.

Documentation additions:

* Added new user guide pages to the sitemap: `where-does-striae-fit.md`, `accessing-striae-registration-and-login.md`, and `authenticating-with-cloudflare-warp.md` under the "Getting Started" section. ([app/routes/sitemap[.]xml.tsxR35-R38](diffhunk://#diff-2f65c4fb5ceb8129b6774ff9564092bdd5151706c80c05bfd3951679adec1356R35-R38))

Documentation reorganization:

* Replaced the path for confirmations guide with `authenticated-confirmations.md` under a new directory, and updated the audit trail guide path to `audit-trail-system.md` under a new directory, reflecting a restructuring of these sections. ([app/routes/sitemap[.]xml.tsxL46-R58](diffhunk://#diff-2f65c4fb5ceb8129b6774ff9564092bdd5151706c80c05bfd3951679adec1356L46-R58))

Release notes update:

* Added the latest release notes file `RELEASE_NOTES_v1.1.2.md` to the sitemap for improved visibility of recent changes. ([app/routes/sitemap[.]xml.tsxL46-R58](diffhunk://#diff-2f65c4fb5ceb8129b6774ff9564092bdd5151706c80c05bfd3951679adec1356L46-R58))