### PR TITLE
fix support, bugs return logo link positioning

### DIFF
--- a/app/routes/bugs/bugs.module.css
+++ b/app/routes/bugs/bugs.module.css
@@ -77,18 +77,21 @@
 
 /* Mobile Responsive */
 @media (max-width: 1024px) {
+  .container {
+    flex-direction: column;
+  }
+
   .logo {
     display: none;
   }
 
   .returnLink {
     display: block;
-    margin-left: auto;
-    margin-right: auto;
+    margin: 0 auto var(--spaceM);
   }
 
   .formWrapper {
     padding: var(--spaceL);
-    margin: var(--spaceM);
+    margin: var(--spaceM) auto;
   }
 }

--- a/app/routes/support/support.module.css
+++ b/app/routes/support/support.module.css
@@ -77,18 +77,21 @@
 
 /* Mobile Responsive */
 @media (max-width: 1024px) {
+  .container {
+    flex-direction: column;
+  }
+
   .logo {
     display: none;
   }
 
   .returnLink {
     display: block;
-    margin-left: auto;
-    margin-right: auto;
+    margin: 0 auto var(--spaceM);
   }
 
   .formWrapper {
     padding: var(--spaceL);
-    margin: var(--spaceM);
+    margin: var(--spaceM) auto;
   }
 }


### PR DESCRIPTION
This pull request improves the mobile responsiveness of the bugs and support pages by updating their respective CSS modules. The main change is to adjust the layout for screens with a maximum width of 1024px, making the container layout vertical and refining margin and padding for better appearance and usability on mobile devices.

Mobile responsiveness improvements:

* Added `.container { flex-direction: column; }` in the mobile media query to make the layout vertical for both `bugs.module.css` and `support.module.css`.
* Updated `.returnLink` and `.formWrapper` margin styles for better centering and spacing on mobile devices in both files.