### PR TITLE
migrate to RSASSA-PSS

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -20,6 +20,12 @@ Striae is a specialized, cloud-native platform designed to streamline forensic f
 
 ## 📋 Changelog
 
+## [2026-04-11] - *Cryptography Update (Unreleased)*
+
+- **🔐 Forensic Signature Algorithm Cutover** - Switched forensic manifest, confirmation export, and bundled audit-export signing/verification from `RSASSA-PKCS1-v1_5-SHA-256` to `RSASSA-PSS-SHA-256` with RSA-PSS salt length `32`.
+- **🧾 Signature Contract Version Bump** - Bumped signing contracts to `manifestVersion: 3.0`, `confirmation signatureVersion: 3.0`, and `audit export signatureVersion: 2.0` to make the cryptographic change explicit.
+- **⚠️ Breaking Verification Behavior** - This is a hard cutover. Pre-cutover PKCS1-signed exports are expected to fail signature verification/import under the new contract.
+
 ## [2026-04-10] - *[Patch Release v5.5.2](https://github.com/striae-org/striae/releases/tag/v5.5.2)*
 
 - **🔐 Registration Gateway Development** - Implemented registration gateway development work to enhance user onboarding flows and auth integration patterns with related code review adjustments.

--- a/app/utils/forensics/SHA256.ts
+++ b/app/utils/forensics/SHA256.ts
@@ -6,8 +6,8 @@
 
 import { verifySignaturePayload } from './signature-utils';
 
-export const FORENSIC_MANIFEST_VERSION = '2.0';
-export const FORENSIC_MANIFEST_SIGNATURE_ALGORITHM = 'RSASSA-PKCS1-v1_5-SHA-256';
+export const FORENSIC_MANIFEST_VERSION = '3.0';
+export const FORENSIC_MANIFEST_SIGNATURE_ALGORITHM = 'RSASSA-PSS-SHA-256';
 
 export interface ForensicManifestData {
   dataHash: string;

--- a/app/utils/forensics/audit-export-signature.ts
+++ b/app/utils/forensics/audit-export-signature.ts
@@ -5,7 +5,7 @@ import {
 } from './SHA256';
 import { verifySignaturePayload } from './signature-utils';
 
-export const AUDIT_EXPORT_SIGNATURE_VERSION = '1.0';
+export const AUDIT_EXPORT_SIGNATURE_VERSION = '2.0';
 
 const SHA256_HEX_REGEX = /^[a-f0-9]{64}$/i;
 

--- a/app/utils/forensics/confirmation-signature.ts
+++ b/app/utils/forensics/confirmation-signature.ts
@@ -6,7 +6,7 @@ import {
 } from './SHA256';
 import { verifySignaturePayload } from './signature-utils';
 
-export const CONFIRMATION_SIGNATURE_VERSION = '2.0';
+export const CONFIRMATION_SIGNATURE_VERSION = '3.0';
 
 const SHA256_HEX_REGEX = /^[a-f0-9]{64}$/i;
 

--- a/app/utils/forensics/signature-utils.ts
+++ b/app/utils/forensics/signature-utils.ts
@@ -29,6 +29,8 @@ export interface PublicSigningKeyDetails {
   publicKeyPem: string | null;
 }
 
+const RSA_PSS_SALT_LENGTH = 32;
+
 type ManifestSigningConfig = {
   manifest_signing_public_keys?: Record<string, string>;
   manifest_signing_public_key?: string;
@@ -197,7 +199,7 @@ export async function verifySignaturePayload(
       'spki',
       publicKeyPemToArrayBuffer(publicKeyPem, invalidPublicKeyError),
       {
-        name: 'RSASSA-PKCS1-v1_5',
+        name: 'RSA-PSS',
         hash: 'SHA-256'
       },
       false,
@@ -209,7 +211,10 @@ export async function verifySignaturePayload(
     signatureBuffer.set(signatureBytes);
 
     const verified = await crypto.subtle.verify(
-      { name: 'RSASSA-PKCS1-v1_5' },
+      {
+        name: 'RSA-PSS',
+        saltLength: RSA_PSS_SALT_LENGTH
+      },
       key,
       signatureBuffer,
       new TextEncoder().encode(payload)

--- a/workers/audit-worker/wrangler.jsonc.example
+++ b/workers/audit-worker/wrangler.jsonc.example
@@ -7,7 +7,7 @@
   "name": "AUDIT_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/audit-worker.ts",
-  "compatibility_date": "2026-04-10",
+  "compatibility_date": "2026-04-11",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/data-worker/src/signature-utils.ts
+++ b/workers/data-worker/src/signature-utils.ts
@@ -5,6 +5,8 @@ export interface WorkerSignatureEnvelope {
   value: string;
 }
 
+const RSA_PSS_SALT_LENGTH = 32;
+
 function base64UrlEncode(value: Uint8Array): string {
   let binary = '';
   for (const byte of value) {
@@ -57,7 +59,7 @@ export async function signPayload(
     'pkcs8',
     parsePkcs8PrivateKey(privateKey),
     {
-      name: 'RSASSA-PKCS1-v1_5',
+      name: 'RSA-PSS',
       hash: 'SHA-256'
     },
     false,
@@ -65,7 +67,10 @@ export async function signPayload(
   );
 
   const signature = await crypto.subtle.sign(
-    { name: 'RSASSA-PKCS1-v1_5' },
+    {
+      name: 'RSA-PSS',
+      saltLength: RSA_PSS_SALT_LENGTH
+    },
     signingKey,
     new TextEncoder().encode(payload)
   );

--- a/workers/data-worker/src/signing-payload-utils.ts
+++ b/workers/data-worker/src/signing-payload-utils.ts
@@ -52,10 +52,10 @@ export interface AuditExportSigningPayload {
   hash: string;
 }
 
-export const FORENSIC_MANIFEST_VERSION = '2.0';
-export const CONFIRMATION_SIGNATURE_VERSION = '2.0';
-export const AUDIT_EXPORT_SIGNATURE_VERSION = '1.0';
-export const FORENSIC_MANIFEST_SIGNATURE_ALGORITHM = 'RSASSA-PKCS1-v1_5-SHA-256';
+export const FORENSIC_MANIFEST_VERSION = '3.0';
+export const CONFIRMATION_SIGNATURE_VERSION = '3.0';
+export const AUDIT_EXPORT_SIGNATURE_VERSION = '2.0';
+export const FORENSIC_MANIFEST_SIGNATURE_ALGORITHM = 'RSASSA-PSS-SHA-256';
 
 const SHA256_HEX_REGEX = /^[a-f0-9]{64}$/i;
 

--- a/workers/data-worker/wrangler.jsonc.example
+++ b/workers/data-worker/wrangler.jsonc.example
@@ -5,7 +5,7 @@
   "name": "DATA_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/data-worker.ts",
-  "compatibility_date": "2026-04-10",
+  "compatibility_date": "2026-04-11",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/image-worker/wrangler.jsonc.example
+++ b/workers/image-worker/wrangler.jsonc.example
@@ -2,7 +2,7 @@
   "name": "IMAGES_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/image-worker.ts",
-  "compatibility_date": "2026-04-10",
+  "compatibility_date": "2026-04-11",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/pdf-worker/wrangler.jsonc.example
+++ b/workers/pdf-worker/wrangler.jsonc.example
@@ -2,7 +2,7 @@
   "name": "PDF_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/pdf-worker.ts",
-  "compatibility_date": "2026-04-10",
+  "compatibility_date": "2026-04-11",
   "compatibility_flags": [
     "nodejs_compat"
   ],

--- a/workers/user-worker/wrangler.jsonc.example
+++ b/workers/user-worker/wrangler.jsonc.example
@@ -2,7 +2,7 @@
   "name": "USER_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/user-worker.ts",
-  "compatibility_date": "2026-04-10",
+  "compatibility_date": "2026-04-11",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -1,6 +1,6 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "PAGES_PROJECT_NAME"
-compatibility_date = "2026-04-10"
+compatibility_date = "2026-04-11"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./build/client"
 


### PR DESCRIPTION
This pull request introduces a breaking cryptographic update across the forensic manifest, confirmation, and audit export signing/verification processes. The main change is a migration from the `RSASSA-PKCS1-v1_5-SHA-256` signature scheme to the more secure `RSASSA-PSS-SHA-256` with a fixed salt length, along with corresponding version bumps for signature contracts. This affects both signing and verification logic, and will invalidate previous exports signed with the old scheme.

**Cryptography: Signature Algorithm Cutover**

* Changed all forensic manifest, confirmation, and audit export signing and verification from `RSASSA-PKCS1-v1_5-SHA-256` to `RSASSA-PSS-SHA-256` with a salt length of 32, updating both signing and verification logic in `signature-utils.ts` and `data-worker/src/signature-utils.ts` [[1]](diffhunk://#diff-aa796bb55cabcfdf7350b1c96abbf1693d53d3111647667070110900a00e2998L200-R202) [[2]](diffhunk://#diff-aa796bb55cabcfdf7350b1c96abbf1693d53d3111647667070110900a00e2998L212-R217) [[3]](diffhunk://#diff-1e7319ed98104f1cc84a8782043b00ba8c45072cc18bc0e62c7a0275bb5c463aL60-R73).
* Updated signature algorithm identifier constants to reflect the new algorithm in both client and worker code (`SHA256.ts`, `signing-payload-utils.ts`) [[1]](diffhunk://#diff-aaf3d3e87acd243e2c30e175ae4d738ac3c1c84540c40ce88a85c6510622237dL9-R10) [[2]](diffhunk://#diff-1eb0a3aca7829d5ffaee72c697d4ee8330f32c2943d8c9d28d7a2ce11dfb16d1L55-R58).

**Signature Contract Versioning**

* Bumped manifest, confirmation, and audit export signature versions to make the cryptographic change explicit: manifest to `3.0`, confirmation to `3.0`, and audit export to `2.0` [[1]](diffhunk://#diff-aaf3d3e87acd243e2c30e175ae4d738ac3c1c84540c40ce88a85c6510622237dL9-R10) [[2]](diffhunk://#diff-fefad286fd3577246bee74037e2c45d4ab0eba962d33571a1b11d8cb78a308bfL9-R9) [[3]](diffhunk://#diff-4e2dcb25b6d47200851772319ced55439ac50508553627877c4bc6f7f37f753fL8-R8) [[4]](diffhunk://#diff-1eb0a3aca7829d5ffaee72c697d4ee8330f32c2943d8c9d28d7a2ce11dfb16d1L55-R58).

**Breaking Change Notice**

* Added documentation in the changelog to highlight that pre-cutover PKCS1-signed exports will fail verification/import under the new contract (`.github/README.md`).

**Worker & Project Configuration**

* Updated `compatibility_date` to `2026-04-11` in all worker and project configuration files to align with the cryptographic cutover (`wrangler.toml.example`, all `wrangler.jsonc.example` files) [[1]](diffhunk://#diff-f46aecc9ef219c92b725dba6fc747384927016bcfe870946334f587d145e1454L3-R3) [[2]](diffhunk://#diff-a06bd34d808c6d17bced83f7809fdc3cc67dbd9e9660d6fca84465f89b3c3d28L8-R8) [[3]](diffhunk://#diff-e1d3129c96b6720c42ba1122071136b06284163dfb6f166c78e23c298d5ab0a1L5-R5) [[4]](diffhunk://#diff-4645a382213755d06092c726a199073136b1ffd843a8581bb127b509e90783b9L5-R5) [[5]](diffhunk://#diff-2f63fd80985909733991b5f726934a04b6247e849aab2946763e8d1b55eba4ebL5-R5) [[6]](diffhunk://#diff-1a6087ffb2a3e27bd4d44cde8f8c758f6898e55de22ae50959d430ffb241bb5dL10-R10).

**Internal Constants**

* Introduced a shared constant for RSA-PSS salt length (`RSA_PSS_SALT_LENGTH = 32`) in both client and worker signing utilities [[1]](diffhunk://#diff-aa796bb55cabcfdf7350b1c96abbf1693d53d3111647667070110900a00e2998R32-R33) [[2]](diffhunk://#diff-1e7319ed98104f1cc84a8782043b00ba8c45072cc18bc0e62c7a0275bb5c463aR8-R9).

This is a coordinated, breaking upgrade to cryptographic signing and verification. All systems must be updated together, and existing PKCS1-signed artifacts will no longer be accepted.