### PR TITLE
bump v6.0.0

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -20,11 +20,13 @@ Striae is a specialized, cloud-native platform designed to streamline forensic f
 
 ## 📋 Changelog
 
-## [2026-04-11] - *Cryptography Update (Unreleased)*
+## [2026-04-11] - *[Major Release v6.0.0](https://github.com/striae-org/striae/releases/tag/v6.0.0)*
 
 - **🔐 Forensic Signature Algorithm Cutover** - Switched forensic manifest, confirmation export, and bundled audit-export signing/verification from `RSASSA-PKCS1-v1_5-SHA-256` to `RSASSA-PSS-SHA-256` with RSA-PSS salt length `32`.
 - **🧾 Signature Contract Version Bump** - Bumped signing contracts to `manifestVersion: 3.0`, `confirmation signatureVersion: 3.0`, and `audit export signatureVersion: 2.0` to make the cryptographic change explicit.
 - **⚠️ Breaking Verification Behavior** - This is a hard cutover. Pre-cutover PKCS1-signed exports are expected to fail signature verification/import under the new contract.
+- **🗂️ Archive Workflow Refinements** - Refactored archive bundle export into shared helpers and tightened archive import alerts/messaging behavior.
+- **🛠️ Release-Window Deployment and Packaging Maintenance** - Included deployment script updates, package script adjustments, and related release-window maintenance commits from 2026-04-10 through 2026-04-11.
 
 ## [2026-04-10] - *[Patch Release v5.5.2](https://github.com/striae-org/striae/releases/tag/v5.5.2)*
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version     | Supported          |
 | ----------- | ------------------ |
-| v5.5.2  | :white_check_mark: |
+| v6.0.0  | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/.github/release-notes/RELEASE_NOTES_v6.0.0.md
+++ b/.github/release-notes/RELEASE_NOTES_v6.0.0.md
@@ -1,0 +1,43 @@
+# Striae Release Notes - v6.0.0
+
+**Release Date**: April 11, 2026
+**Period**: April 10, 2026 through April 11, 2026
+**Total Commits**: 15 (non-merge since 04/10/2026)
+
+## Major Release - Cryptographic Contract Cutover and Archive Workflow Refinements
+
+## Summary
+
+v6.0.0 introduces a cryptographic contract cutover from RSA PKCS#1 v1.5 signatures to RSA-PSS signatures across manifest, confirmation export, and bundled audit export workflows. This release also includes archive import/export UX and flow refinements, plus deployment and package-script maintenance commits from the release window beginning 04/10/2026.
+
+## Detailed Changes
+
+### Forensic Signature Algorithm Cutover (Breaking)
+
+- Migrated signing and verification flows from `RSASSA-PKCS1-v1_5-SHA-256` to `RSASSA-PSS-SHA-256` with RSA-PSS salt length `32`.
+- Updated signing contract versions (`manifestVersion: 3.0`, confirmation `signatureVersion: 3.0`, audit export `signatureVersion: 2.0`) to explicitly represent the cryptographic change.
+- This is a hard cutover: pre-cutover PKCS#1-signed artifacts are expected to fail verification/import under the new contract.
+
+### Archive Workflow Refinements
+
+- Refactored archive bundle export into shared helpers to reduce route-level duplication and improve maintainability.
+- Consolidated archive import alerts and refined archive import messaging for clearer user feedback during archive operations.
+
+### Deployment, Packaging, and Release Window Maintenance
+
+- Included package/deploy script updates and deployment reliability fixes during the same release window.
+- Carried forward registration gateway and compatibility/environment/package-list maintenance commits included since 04/10/2026.
+- Included release-window code review follow-up commits.
+
+## Release Statistics
+
+- **Baseline**: `release-notes/RELEASE_NOTES_v5.5.2.md`
+- **Commit Range**: `a6fe9207..3b35a467`
+- **Commits Included**: 15 (non-merge commits since 04/10/2026)
+- **Build Status**: Passed (`npm run build`)
+- **Typecheck Status**: Passed (`npm run typecheck`)
+- **Lint Status**: Passed with expected warnings in generated `worker-configuration.d.ts` files (`npm run lint`)
+
+## Closing Note
+
+v6.0.0 marks a security-focused major release with intentional signature-contract breaking changes while continuing archive workflow refinement and deployment/package maintenance in the same development window.

--- a/.github/release-notes/RELEASE_NOTES_v6.0.0.md
+++ b/.github/release-notes/RELEASE_NOTES_v6.0.0.md
@@ -31,7 +31,7 @@ v6.0.0 introduces a cryptographic contract cutover from RSA PKCS#1 v1.5 signatur
 
 ## Release Statistics
 
-- **Baseline**: `release-notes/RELEASE_NOTES_v5.5.2.md`
+- **Baseline**: `.github/release-notes/RELEASE_NOTES_v5.5.2.md`
 - **Commit Range**: `a6fe9207..3b35a467`
 - **Commits Included**: 15 (non-merge commits since 04/10/2026)
 - **Build Status**: Passed (`npm run build`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@striae-org/striae",
-  "version": "5.5.2",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@striae-org/striae",
-      "version": "5.5.2",
+      "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-router/cloudflare": "^7.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@striae-org/striae",
-  "version": "5.5.2",
+  "version": "6.0.0",
   "private": false,
   "description": "Striae is a specialized, cloud-native platform designed to streamline forensic firearms identification by providing an intuitive environment for digital comparison image annotation, authenticated confirmations, and automated report generation.",
   "license": "Apache-2.0",

--- a/workers/audit-worker/package-lock.json
+++ b/workers/audit-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audit-worker",
-  "version": "5.5.2",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audit-worker",
-      "version": "5.5.2",
+      "version": "6.0.0",
       "devDependencies": {
         "wrangler": "^4.81.1"
       }

--- a/workers/audit-worker/package.json
+++ b/workers/audit-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-worker",
-  "version": "5.5.2",
+  "version": "6.0.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/data-worker/package-lock.json
+++ b/workers/data-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-worker",
-  "version": "5.5.2",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "data-worker",
-      "version": "5.5.2",
+      "version": "6.0.0",
       "devDependencies": {
         "wrangler": "^4.81.1"
       }

--- a/workers/data-worker/package.json
+++ b/workers/data-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-worker",
-  "version": "5.5.2",
+  "version": "6.0.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/image-worker/package-lock.json
+++ b/workers/image-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-worker",
-  "version": "5.5.2",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-worker",
-      "version": "5.5.2",
+      "version": "6.0.0",
       "devDependencies": {
         "wrangler": "^4.81.1"
       }

--- a/workers/image-worker/package.json
+++ b/workers/image-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-worker",
-  "version": "5.5.2",
+  "version": "6.0.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/pdf-worker/package-lock.json
+++ b/workers/pdf-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdf-worker",
-  "version": "5.5.2",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-worker",
-      "version": "5.5.2",
+      "version": "6.0.0",
       "devDependencies": {
         "wrangler": "^4.81.1"
       }

--- a/workers/pdf-worker/package.json
+++ b/workers/pdf-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-worker",
-  "version": "5.5.2",
+  "version": "6.0.0",
   "private": true,
   "scripts": {
     "generate:assets": "node scripts/generate-assets.js",

--- a/workers/user-worker/package-lock.json
+++ b/workers/user-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "user-worker",
-  "version": "5.5.2",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "user-worker",
-      "version": "5.5.2",
+      "version": "6.0.0",
       "devDependencies": {
         "wrangler": "^4.81.1"
       }

--- a/workers/user-worker/package.json
+++ b/workers/user-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-worker",
-  "version": "5.5.2",
+  "version": "6.0.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",


### PR DESCRIPTION
This pull request marks the v6.0.0 major release for Striae, focusing on a cryptographic contract cutover, archive workflow improvements, and deployment/package maintenance. The most important changes are grouped below:

**Cryptography and Security**

* Migrated all forensic signature signing/verification from `RSASSA-PKCS1-v1_5-SHA-256` to the more secure `RSASSA-PSS-SHA-256` with a salt length of 32, and updated signature contract versions to make this change explicit. This is a breaking change: pre-v6.0.0 PKCS#1-signed exports will fail verification/import under the new contract. (`.github/README.md` [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5L23-R29) `.github/release-notes/RELEASE_NOTES_v6.0.0.md` [[2]](diffhunk://#diff-2c617b8657ba2d6c0c496050470043ad5fe3b4784801796f8cd0a0a80f870c2eR1-R43)

* Updated the supported version in `.github/SECURITY.md` to v6.0.0.

**Archive Workflow and UX**

* Refactored archive bundle export logic into shared helpers and improved archive import alerts and messaging for a better user experience. (`.github/README.md` [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5L23-R29) `.github/release-notes/RELEASE_NOTES_v6.0.0.md` [[2]](diffhunk://#diff-2c617b8657ba2d6c0c496050470043ad5fe3b4784801796f8cd0a0a80f870c2eR1-R43)

**Deployment and Packaging**

* Performed deployment script updates, package script adjustments, and other release-window maintenance. (`.github/README.md` [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5L23-R29) `.github/release-notes/RELEASE_NOTES_v6.0.0.md` [[2]](diffhunk://#diff-2c617b8657ba2d6c0c496050470043ad5fe3b4784801796f8cd0a0a80f870c2eR1-R43)

**Version Bumps**

* Bumped the version to `6.0.0` in all relevant `package.json` and `package-lock.json` files for the main app and all workers. (`package.json` [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) `workers/*/package.json` [[2]](diffhunk://#diff-d16fb6b09f684160054b5c0e353e35f63f00651bc94bcbcaf521437dfccd9fc9L3-R3) [[3]](diffhunk://#diff-25a913066a7fe613d4b06888c5c4429d3115d670e3a47c1e0093f93ac69b0bc6L3-R3) [[4]](diffhunk://#diff-6b488296f955b235077b13eb5a4be1d4fbec35413644445e150b93f1800aec71L3-R3) [[5]](diffhunk://#diff-0e896c71a77804a30199ade801c401da5f6343c86e21a0e184974feb2a80a941L3-R3) [[6]](diffhunk://#diff-0c2ca2d4f71077b08e99fbcf3b51ff4afd93456ac56a1cfa279ef8ce62e9b445L3-R3); `workers/*/package-lock.json` [[7]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L3-R9) [[8]](diffhunk://#diff-6e5e36a60c0d36c5b64aa73374f62c57efbd072023660e8d0aec12a4280248c9L3-R9) [[9]](diffhunk://#diff-8aaa33f9d5640156d7cec29c58ba66ec9c932b4c106dc397b9558af952100cebL3-R9) [[10]](diffhunk://#diff-1d4408399474dc9865a67a3928dc47144f925b807fcb91fff6d733905d621e66L3-R9) [[11]](diffhunk://#diff-4f2f3beba65f88db2a2cf66fe5915d9f3fd6d730ef00036a75bf9c3d11c2dc7bL3-R9)

**Documentation**

* Added comprehensive release notes for v6.0.0, detailing all major changes, statistics, and the rationale for the release. (`.github/release-notes/RELEASE_NOTES_v6.0.0.md` [.github/release-notes/RELEASE_NOTES_v6.0.0.mdR1-R43](diffhunk://#diff-2c617b8657ba2d6c0c496050470043ad5fe3b4784801796f8cd0a0a80f870c2eR1-R43))