### PR TITLE
bump v6.1.0

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -22,6 +22,12 @@ Striae is a specialized, cloud-native platform designed to streamline forensic f
 
 ## 📋 Changelog
 
+## [2026-04-14] - *[Minor Release v6.1.0](https://github.com/striae-org/striae/releases/tag/v6.1.0)*
+
+- **🧭 Item Model Terminology Refactor** - Completed a broad class-to-item naming/type transition across core data and UI surfaces, including item type/subclass display and control refinements.
+- **🧩 Split Item Data and Reporting** - Added split left/right item datasets, split additional notes, updated summary/notes displays, and aligned PDF report formats plus icon/tool reporting behavior.
+- **🗂️ File Management and Stabilization Follow-Ups** - Refined file-management filtering for split-item workflows and included release-window dependency/code-review maintenance plus archive re-export packaging fixes.
+
 ## [2026-04-12] - *[Patch Release v6.0.1](https://github.com/striae-org/striae/releases/tag/v6.0.1)*
 
 - **🗂️ Archive Import UX Follow-Ups** - Continued archive import alert/messaging refinements from the v6.0.0 release window for clearer archive-operation feedback.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version     | Supported          |
 | ----------- | ------------------ |
-| v6.0.1  | :white_check_mark: |
+| v6.1.0  | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/.github/release-notes/RELEASE_NOTES_v6.1.0.md
+++ b/.github/release-notes/RELEASE_NOTES_v6.1.0.md
@@ -1,0 +1,43 @@
+# Striae Release Notes - v6.1.0
+
+**Release Date**: April 14, 2026
+**Period**: April 12, 2026 through April 14, 2026
+**Total Commits**: 18 (non-merge since 04/12/2026)
+
+## Minor Release - Item Model Refactor and Split Item Data/Reporting
+
+## Summary
+
+v6.1.0 delivers a broad data-model and UX transition from class-centric terminology to item-centric terminology, introduces split left/right item datasets with corresponding notes/reporting updates, and includes release-window stabilization work across dependencies and archive re-export packaging.
+
+## Detailed Changes
+
+### Item Model and Terminology Refactor
+
+- Performed a global type/domain rename from class to item to align terminology across data model, UI text, and interactions.
+- Updated item type/subclass display behavior in canvas and related UI surfaces.
+- Moved subclass controls and adjusted supporting UI copy for clearer item workflow behavior.
+
+### Split Item Data, Notes, and Reporting
+
+- Added split left/right item datasets and propagated split-data support through summary core/display layers.
+- Added split additional-notes handling and updated item notes displays to support the new data shape.
+- Updated item icon/tool handling and PDF reporting formats to reflect split item model/report output requirements.
+
+### File Management and Release-Window Stabilization
+
+- Refined file management filtering behavior to better match the new item data pathways.
+- Included release-window maintenance commits (`bump deps`, `code review`) and a targeted fix for archive re-export packaging.
+
+## Release Statistics
+
+- **Baseline**: `.github/release-notes/RELEASE_NOTES_v6.0.1.md`
+- **Commit Range**: `6e55324a..825109be`
+- **Commits Included**: 18 (non-merge commits since 04/12/2026)
+- **Build Status**: Passed (`npm run build`)
+- **Typecheck Status**: Passed (`npm run typecheck`)
+- **Lint Status**: Passed with expected warnings in generated `worker-configuration.d.ts` files (`npm run lint`)
+
+## Closing Note
+
+v6.1.0 is a feature-focused minor release that establishes split item data/reporting foundations and completes the class-to-item terminology transition while carrying forward targeted reliability and packaging fixes in the same release window.

--- a/app/components/navbar/navbar.tsx
+++ b/app/components/navbar/navbar.tsx
@@ -117,7 +117,8 @@ export const Navbar = ({
   const disableLongRunningCaseActions = isUploading;
   const isCaseManagementActive = true;
   const isFileManagementActive = isFileMenuOpen || hasLoadedImage;
-  const canOpenImageNotes = hasLoadedImage && !isCurrentImageConfirmed;
+  const canOpenImageNotes = hasLoadedImage;
+  const isImageNotesReadOnly = isReadOnly || isCurrentImageConfirmed || isUploading;
   const isImageNotesActive = canOpenImageNotes;
   const canDeleteCurrentFile = hasLoadedImage && !isReadOnly;
   const isArchivedCase = Boolean(isReadOnly && archiveDetails?.archived);
@@ -367,10 +368,8 @@ export const Navbar = ({
             title={
               !hasLoadedImage
                 ? 'Load an image to enable image notes'
-                : isCurrentImageConfirmed
-                  ? 'Confirmed images are read-only and viewable via toolbar only'
-                  : isReadOnly
-                    ? 'Image notes are disabled for read-only cases'
+                : isImageNotesReadOnly
+                  ? 'Image notes are view-only in this state'
                     : undefined
             }
             onClick={() => {

--- a/app/components/navbar/navbar.tsx
+++ b/app/components/navbar/navbar.tsx
@@ -117,11 +117,11 @@ export const Navbar = ({
   const disableLongRunningCaseActions = isUploading;
   const isCaseManagementActive = true;
   const isFileManagementActive = isFileMenuOpen || hasLoadedImage;
-  const canOpenImageNotes = hasLoadedImage && !isCurrentImageConfirmed && !isReadOnly;
+  const canOpenImageNotes = hasLoadedImage && !isCurrentImageConfirmed;
   const isImageNotesActive = canOpenImageNotes;
   const canDeleteCurrentFile = hasLoadedImage && !isReadOnly;
-  const isArchivedRegularReadOnly = Boolean(isReadOnly && archiveDetails?.archived && !isReviewOnlyCase);
-  const caseExportLabel = isArchivedRegularReadOnly
+  const isArchivedCase = Boolean(isReadOnly && archiveDetails?.archived);
+  const caseExportLabel = isArchivedCase
     ? 'Export Archive'
     : isReadOnly
       ? 'Export Confirmations'
@@ -184,13 +184,15 @@ export const Navbar = ({
                   type="button"
                   role="menuitem"
                   className={`${styles.caseMenuItem} ${styles.caseMenuItemExport}`}
-                  disabled={!hasLoadedCase || disableLongRunningCaseActions}
+                  disabled={!hasLoadedCase || disableLongRunningCaseActions || (isArchivedCase && isReviewOnlyCase)}
                   title={
                     !hasLoadedCase
                       ? 'Load a case to export case data'
                       : disableLongRunningCaseActions
                         ? 'Export is unavailable while files are uploading'
-                        : undefined
+                        : isArchivedCase && isReviewOnlyCase
+                          ? 'Cannot export imported archive packages'
+                          : undefined
                   }
                   onClick={() => {
                     onOpenCaseExport?.();

--- a/app/components/sidebar/cases/case-sidebar.tsx
+++ b/app/components/sidebar/cases/case-sidebar.tsx
@@ -26,6 +26,7 @@ interface CaseSidebarProps {
   setFiles: React.Dispatch<React.SetStateAction<FileData[]>>;
   currentCase: string | null;
   isReadOnly?: boolean;
+  isReviewOnlyCase?: boolean;
   isArchivedCase?: boolean;
   isConfirmed?: boolean;
   confirmationSaveVersion?: number;
@@ -47,6 +48,7 @@ export const CaseSidebar = ({
   setFiles,
   currentCase,
   isReadOnly = false,
+  isReviewOnlyCase = false,
   isArchivedCase = false,
   isConfirmed = false,
   confirmationSaveVersion = 0,
@@ -260,11 +262,14 @@ const handleImageSelect = (file: FileData) => {
 
   const showCaseExportButton = Boolean(currentCase && isReadOnly);
   const caseExportButtonLabel = isArchivedCase ? 'Export Archive' : 'Export Confirmations';
+  const isImportedArchive = isArchivedCase && isReviewOnlyCase;
 
   const exportCaseTitle = isUploading
     ? 'Cannot export while uploading'
     : !currentCase
     ? 'Load a case first'
+    : isImportedArchive
+    ? 'Cannot export imported archive packages'
     : undefined;
 
 return (
@@ -389,7 +394,7 @@ return (
         <button
           className={styles.confirmationExportButton}
           onClick={onOpenCaseExport}
-          disabled={isUploading || !currentCase}
+          disabled={isUploading || !currentCase || isImportedArchive}
           title={exportCaseTitle}
         >
           {caseExportButtonLabel}

--- a/app/components/sidebar/notes/addl-notes-modal.tsx
+++ b/app/components/sidebar/notes/addl-notes-modal.tsx
@@ -7,10 +7,11 @@ interface AddlNotesModalProps {
   onClose: () => void;
   notes: string;
   onSave: (notes: string) => void;
+  isReadOnly?: boolean;
   showNotification?: (message: string, type: 'success' | 'error' | 'warning') => void;
 }
 
-export const AddlNotesModal = ({ isOpen, onClose, notes, onSave, showNotification }: AddlNotesModalProps) => {
+export const AddlNotesModal = ({ isOpen, onClose, notes, onSave, isReadOnly = false, showNotification }: AddlNotesModalProps) => {
   const [tempNotes, setTempNotes] = useState(notes);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -31,6 +32,11 @@ export const AddlNotesModal = ({ isOpen, onClose, notes, onSave, showNotificatio
   if (!isOpen) return null;  
 
   const handleSave = async () => {
+    if (isReadOnly) {
+      showNotification?.('This case is read-only. Notes cannot be modified.', 'error');
+      return;
+    }
+
     setIsSaving(true);
     try {
       await Promise.resolve(onSave(tempNotes));
@@ -58,12 +64,13 @@ export const AddlNotesModal = ({ isOpen, onClose, notes, onSave, showNotificatio
           onChange={(e) => setTempNotes(e.target.value)}
           className={styles.modalTextarea}
           placeholder="Enter additional notes..."
+          disabled={isReadOnly}
         />
         <div className={styles.modalButtons}>
           <button 
             onClick={handleSave} 
             className={styles.saveButton}
-            disabled={isSaving}
+            disabled={isSaving || isReadOnly}
             aria-busy={isSaving}
           >
             {isSaving ? 'Saving...' : 'Save'}

--- a/app/components/sidebar/notes/notes-editor-form.tsx
+++ b/app/components/sidebar/notes/notes-editor-form.tsx
@@ -17,6 +17,7 @@ interface NotesEditorFormProps {
   onAnnotationRefresh?: () => void;
   originalFileName?: string;
   isUploading?: boolean;
+  isReadOnly?: boolean;
   showNotification?: (message: string, type: 'success' | 'error' | 'warning') => void;
   onDirtyChange?: (isDirty: boolean) => void;
   onRegisterSaveHandler?: (saveHandler: (() => Promise<boolean>) | null) => void;
@@ -96,7 +97,7 @@ const serializeNotesSnapshot = (snapshot: NotesFormSnapshot): string => JSON.str
 const DIRTY_CHECK_DEBOUNCE_MS = 180;
 const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
-export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefresh, originalFileName, isUploading = false, showNotification: externalShowNotification, onDirtyChange, onRegisterSaveHandler }: NotesEditorFormProps) => {
+export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefresh, originalFileName, isUploading = false, isReadOnly = false, showNotification: externalShowNotification, onDirtyChange, onRegisterSaveHandler }: NotesEditorFormProps) => {
   // Loading/Saving Notes States
   const [isLoading, setIsLoading] = useState(false);
   const [loadError, setLoadError] = useState<string>();
@@ -154,7 +155,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
   const [savedSnapshot, setSavedSnapshot] = useState<string>('');
   const [hasLoadedSnapshot, setHasLoadedSnapshot] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
-  const areInputsDisabled = isUploading || isConfirmedImage;
+  const areInputsDisabled = isUploading || isConfirmedImage || isReadOnly;
 
   const notificationHandler = useCallback((message: string, type: 'success' | 'error' | 'warning' = 'success') => {
     if (externalShowNotification) {
@@ -447,6 +448,11 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
       return false;
     }
 
+    if (isReadOnly) {
+      notificationHandler('This case is read-only. Notes cannot be modified.', 'error');
+      return false;
+    }
+
     let existingData: AnnotationData | null = null;
     
     try {
@@ -619,6 +625,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
     indexColor,
     indexNumber,
     indexType,
+    isReadOnly,
     leftCase,
     leftItem,
     notificationHandler,
@@ -779,7 +786,6 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                 value={selectedItem}
                 onChange={(e) => setSelectedItem(e.target.value as 'left' | 'right')}
                 className={styles.select}
-                disabled={areInputsDisabled}
               >
                 <option value="left">{`Case: ${leftCase || '—'} Item: ${leftItem || '—'}`}</option>
                 <option value="right" disabled={!rightItem && !rightCase}>
@@ -830,7 +836,6 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                   type="button"
                   onClick={() => setIsClassDetailsOpen(true)}
                   className={styles.itemDetailsButton}
-                  disabled={areInputsDisabled}
                 >
                   Class Characteristics & GRC
                 </button>
@@ -955,7 +960,6 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
           <button 
             onClick={() => setIsModalOpen(true)}
             className={styles.notesButton}
-            disabled={areInputsDisabled}
             title={isConfirmedImage ? "Cannot edit notes for confirmed images" : isUploading ? "Cannot add notes while uploading" : undefined}
           >
             Additional Notes
@@ -977,6 +981,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
         onClose={() => setIsModalOpen(false)}
         notes={additionalNotes}
         onSave={setAdditionalNotes}
+        isReadOnly={isReadOnly}
         showNotification={notificationHandler}
       />
       <ItemDetailsModal
@@ -1002,7 +1007,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
           }
         }}
         showNotification={notificationHandler}
-        isReadOnly={areInputsDisabled}
+        isReadOnly={isReadOnly}
       />
       </>
         )}

--- a/app/components/sidebar/notes/notes-editor-form.tsx
+++ b/app/components/sidebar/notes/notes-editor-form.tsx
@@ -32,7 +32,6 @@ interface NotesFormSnapshot {
   leftItem: string;
   rightItem: string;
   caseFontColor: string;
-  selectedItem: 'left' | 'right';
   // Left item class characteristics
   leftItemType: ItemType | '';
   leftCustomClass: string;
@@ -227,7 +226,6 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
         leftItem,
         rightItem,
         caseFontColor,
-        selectedItem,
         leftItemType,
         leftCustomClass,
         leftClassNote,
@@ -285,7 +283,6 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
     rightShotshellData,
     caseFontColor,
     savedSnapshot,
-    selectedItem,
     leftAdditionalNotes,
     rightAdditionalNotes,
     supportLevel,
@@ -358,7 +355,6 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
             leftItem: existingNotes.leftItem || '',
             rightItem: existingNotes.rightItem || '',
             caseFontColor: existingNotes.caseFontColor || '',
-            selectedItem: 'left',
             leftItemType: migratedLeftItemType,
             leftCustomClass: migratedLeftCustomClass,
             leftClassNote: migratedLeftClassNote,
@@ -391,7 +387,6 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
             leftItem: '',
             rightItem: '',
             caseFontColor: '',
-            selectedItem: 'left',
             leftItemType: '',
             leftCustomClass: '',
             leftClassNote: '',
@@ -549,7 +544,6 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
         leftItem,
         rightItem,
         caseFontColor,
-        selectedItem,
         leftItemType,
         leftCustomClass,
         leftClassNote,
@@ -642,7 +636,6 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
     rightItem,
     rightShotshellData,
     leftShotshellData,
-    selectedItem,
     leftAdditionalNotes,
     rightAdditionalNotes,
     supportLevel,
@@ -980,8 +973,14 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         notes={additionalNotes}
-        onSave={setAdditionalNotes}
-        isReadOnly={isReadOnly}
+        onSave={(notes) => {
+          if (areInputsDisabled) {
+            return;
+          }
+
+          setAdditionalNotes(notes);
+        }}
+        isReadOnly={areInputsDisabled}
         showNotification={notificationHandler}
       />
       <ItemDetailsModal
@@ -992,6 +991,10 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
         cartridgeCaseData={getSelectedItemData().cartridgeCaseData}
         shotshellData={getSelectedItemData().shotshellData}
         onSave={(b, c, s) => {
+          if (areInputsDisabled) {
+            return;
+          }
+
           setSelectedItemData({
             bulletData: b,
             cartridgeCaseData: c,
@@ -1007,7 +1010,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
           }
         }}
         showNotification={notificationHandler}
-        isReadOnly={isReadOnly}
+        isReadOnly={areInputsDisabled}
       />
       </>
         )}

--- a/app/components/sidebar/notes/notes-editor-modal.tsx
+++ b/app/components/sidebar/notes/notes-editor-modal.tsx
@@ -13,6 +13,7 @@ interface NotesEditorModalProps {
   originalFileName?: string;
   onAnnotationRefresh?: () => void;
   isUploading?: boolean;
+  isReadOnly?: boolean;
   showNotification?: (message: string, type: 'success' | 'error' | 'warning') => void;
 }
 
@@ -25,6 +26,7 @@ export const NotesEditorModal = ({
   originalFileName,
   onAnnotationRefresh,
   isUploading = false,
+  isReadOnly = false,
   showNotification,
 }: NotesEditorModalProps) => {
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
@@ -186,6 +188,7 @@ export const NotesEditorModal = ({
             onAnnotationRefresh={onAnnotationRefresh}
             originalFileName={originalFileName}
             isUploading={isUploading}
+            isReadOnly={isReadOnly}
             showNotification={showNotification}
             onDirtyChange={handleDirtyChange}
             onRegisterSaveHandler={handleRegisterSaveHandler}

--- a/app/components/sidebar/sidebar-container.tsx
+++ b/app/components/sidebar/sidebar-container.tsx
@@ -24,6 +24,7 @@ interface SidebarContainerProps {
   setShowNotes: (show: boolean) => void;
   onAnnotationRefresh?: () => void;
   isReadOnly?: boolean;
+  isReviewOnlyCase?: boolean;
   isArchivedCase?: boolean;
   isConfirmed?: boolean;
   confirmationSaveVersion?: number;

--- a/app/components/sidebar/sidebar.tsx
+++ b/app/components/sidebar/sidebar.tsx
@@ -20,6 +20,7 @@ interface SidebarProps {
   setShowNotes: (show: boolean) => void;
   onAnnotationRefresh?: () => void;
   isReadOnly?: boolean;
+  isReviewOnlyCase?: boolean;
   isArchivedCase?: boolean;
   isConfirmed?: boolean;
   confirmationSaveVersion?: number;
@@ -40,6 +41,7 @@ export const Sidebar = ({
   setFiles,
   setShowNotes,
   isReadOnly = false,
+  isReviewOnlyCase = false,
   isArchivedCase = false,
   isConfirmed = false,
   confirmationSaveVersion = 0,
@@ -89,6 +91,7 @@ export const Sidebar = ({
         setFiles={setFiles}
         onNotesClick={() => setShowNotes(true)}
         isReadOnly={isReadOnly}
+        isReviewOnlyCase={isReviewOnlyCase}
         isArchivedCase={isArchivedCase}
         isConfirmed={isConfirmed}
         confirmationSaveVersion={confirmationSaveVersion}

--- a/app/routes/striae/striae.tsx
+++ b/app/routes/striae/striae.tsx
@@ -866,6 +866,7 @@ export const Striae = ({ user }: StriaePage) => {
           setShowNotes={setShowNotes}
           onAnnotationRefresh={refreshAnnotationData}
           isReadOnly={isReadOnlyCase}
+          isReviewOnlyCase={isReviewOnlyCase}
           isArchivedCase={archiveDetails.archived}
           isConfirmed={!!annotationData?.confirmationData}
           confirmationSaveVersion={confirmationSaveVersion}
@@ -946,6 +947,7 @@ export const Striae = ({ user }: StriaePage) => {
         onAnnotationRefresh={refreshAnnotationData}
         originalFileName={files.find(file => file.id === imageId)?.originalFilename}
         isUploading={isUploading}
+        isReadOnly={isReadOnlyCase}
         showNotification={showNotification}
       />
       <UserAuditViewer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@striae-org/striae",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@striae-org/striae",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-router/cloudflare": "^7.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@striae-org/striae",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "private": false,
   "description": "Striae is a specialized, cloud-native platform designed to streamline forensic firearms identification by providing an intuitive environment for digital comparison image annotation, authenticated confirmations, and automated report generation.",
   "license": "Apache-2.0",
@@ -136,5 +136,5 @@
   "engines": {
     "node": ">=20.19.0"
   },
-  "packageManager": "npm@11.11.0"
+  "packageManager": "npm@11.12.0"
 }

--- a/workers/audit-worker/package-lock.json
+++ b/workers/audit-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audit-worker",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audit-worker",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "devDependencies": {
         "wrangler": "^4.82.2"
       }

--- a/workers/audit-worker/package.json
+++ b/workers/audit-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-worker",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/data-worker/package-lock.json
+++ b/workers/data-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-worker",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "data-worker",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "devDependencies": {
         "wrangler": "^4.82.2"
       }

--- a/workers/data-worker/package.json
+++ b/workers/data-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-worker",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/image-worker/package-lock.json
+++ b/workers/image-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-worker",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-worker",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "devDependencies": {
         "wrangler": "^4.82.2"
       }

--- a/workers/image-worker/package.json
+++ b/workers/image-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-worker",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/pdf-worker/package-lock.json
+++ b/workers/pdf-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdf-worker",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-worker",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "devDependencies": {
         "wrangler": "^4.82.2"
       }

--- a/workers/pdf-worker/package.json
+++ b/workers/pdf-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-worker",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "private": true,
   "scripts": {
     "generate:assets": "node scripts/generate-assets.js",

--- a/workers/user-worker/package-lock.json
+++ b/workers/user-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "user-worker",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "user-worker",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "devDependencies": {
         "wrangler": "^4.82.2"
       }

--- a/workers/user-worker/package.json
+++ b/workers/user-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-worker",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",


### PR DESCRIPTION
This pull request delivers the Striae v6.1.0 minor release, focusing on a comprehensive refactor from class-centric to item-centric terminology, the introduction of split left/right item data and reporting, and improved file management and export controls. Additionally, it enhances read-only and review-only case handling throughout the UI, ensuring that notes and exports are properly restricted when appropriate.

**Core platform and UI improvements:**

- **Item Model Terminology Refactor**
  * Refactored the codebase and UI from "class" to "item" terminology, updating data models, UI text, and controls for clarity and consistency. (.github/README.md [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R25-R30) .github/release-notes/RELEASE_NOTES_v6.1.0.md [[2]](diffhunk://#diff-da20650dabfe95094eebc3225242c2ed0aeac908d80482447d90ffb2f78f51feR1-R43)

- **Split Item Data and Reporting**
  * Introduced support for split left/right item datasets, notes, and reporting, including updates to summary displays, PDF reports, and icon/tool handling to align with the new item model. (.github/README.md [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R25-R30) .github/release-notes/RELEASE_NOTES_v6.1.0.md [[2]](diffhunk://#diff-da20650dabfe95094eebc3225242c2ed0aeac908d80482447d90ffb2f78f51feR1-R43)

**File management and export controls:**

- **File Management Refinements**
  * Improved file management filtering to support the split-item workflow and addressed archive re-export packaging bugs. (.github/README.md [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R25-R30) .github/release-notes/RELEASE_NOTES_v6.1.0.md [[2]](diffhunk://#diff-da20650dabfe95094eebc3225242c2ed0aeac908d80482447d90ffb2f78f51feR1-R43)

- **Read-Only and Review-Only Case Handling**
  * Enhanced logic throughout the sidebar, notes modals, and navbar to correctly identify and restrict actions (such as notes editing and case export) for read-only and review-only (imported archive) cases, including new props and UI feedback. (app/components/sidebar/cases/case-sidebar.tsx [[1]](diffhunk://#diff-2c659bc7b556cebb90e039cae37462884e1b78562ddc062d7ecb6b48c7d5ff9dR29) [[2]](diffhunk://#diff-2c659bc7b556cebb90e039cae37462884e1b78562ddc062d7ecb6b48c7d5ff9dR51) [[3]](diffhunk://#diff-2c659bc7b556cebb90e039cae37462884e1b78562ddc062d7ecb6b48c7d5ff9dR265-R272) [[4]](diffhunk://#diff-2c659bc7b556cebb90e039cae37462884e1b78562ddc062d7ecb6b48c7d5ff9dL392-R397) app/components/sidebar/notes/addl-notes-modal.tsx [[5]](diffhunk://#diff-68cac1eb36b38e8320ed8a4ac4e15b2f7f34bb26aa07fb7029bdc5c4d6398aa0R10-R14) [[6]](diffhunk://#diff-68cac1eb36b38e8320ed8a4ac4e15b2f7f34bb26aa07fb7029bdc5c4d6398aa0R35-R39) [[7]](diffhunk://#diff-68cac1eb36b38e8320ed8a4ac4e15b2f7f34bb26aa07fb7029bdc5c4d6398aa0R67-R73) app/components/sidebar/notes/notes-editor-form.tsx [[8]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688R20) [[9]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L99-R100) [[10]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L157-R158) [[11]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688R451-R455) [[12]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688R628) [[13]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L782) [[14]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L833) [[15]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L958) [[16]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688R984) [[17]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L1005-R1010) app/components/sidebar/notes/notes-editor-modal.tsx [[18]](diffhunk://#diff-83a4062a1cc4f0ee3da435963f3813b50b8a4c8f1713f0fbd8902842f1399a3bR16) [[19]](diffhunk://#diff-83a4062a1cc4f0ee3da435963f3813b50b8a4c8f1713f0fbd8902842f1399a3bR29) [[20]](diffhunk://#diff-83a4062a1cc4f0ee3da435963f3813b50b8a4c8f1713f0fbd8902842f1399a3bR191) app/components/sidebar/sidebar-container.tsx [[21]](diffhunk://#diff-5baac56dcd806d06ba58691712849f757640fd3bea3141f7e2b4c4f41d071c3dR27) app/components/sidebar/sidebar.tsx [[22]](diffhunk://#diff-5bb4e76ac5fb82c7b0008858f1a4c51e99b3879a29df6b2a603e675e580a4a18R23) [[23]](diffhunk://#diff-5bb4e76ac5fb82c7b0008858f1a4c51e99b3879a29df6b2a603e675e580a4a18R44) [[24]](diffhunk://#diff-5bb4e76ac5fb82c7b0008858f1a4c51e99b3879a29df6b2a603e675e580a4a18R94) app/components/navbar/navbar.tsx [[25]](diffhunk://#diff-170c07400f3cd1a96da61b4cbe57ddc4dc65585e1bee4d9270a2ffc5b82de286L120-R124) [[26]](diffhunk://#diff-170c07400f3cd1a96da61b4cbe57ddc4dc65585e1bee4d9270a2ffc5b82de286L187-R194)

**Documentation and release process:**

- **Release and Security Documentation Updates**
  * Updated the changelog, release notes, and security policy to document v6.1.0, including a summary of changes, statistics, and support status. (.github/README.md [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R25-R30) .github/release-notes/RELEASE_NOTES_v6.1.0.md [[2]](diffhunk://#diff-da20650dabfe95094eebc3225242c2ed0aeac908d80482447d90ffb2f78f51feR1-R43) .github/SECURITY.md [[3]](diffhunk://#diff-ac3050733d58345444c27d37c6247ef260ad992bcb02782feea43fb580106079L7-R7)