### PR TITLE
notes editing permission centralization/refactor

### DIFF
--- a/app/components/colors/colors.module.css
+++ b/app/components/colors/colors.module.css
@@ -26,6 +26,11 @@
   border-color: #adb5bd;
 }
 
+.toggleButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .colorWheel {
   width: 180px;
   height: 40px;
@@ -33,6 +38,11 @@
   border: 2px solid #ced4da;
   border-radius: 4px;
   cursor: pointer;
+}
+
+.colorWheel:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .colorGrid {
@@ -52,6 +62,15 @@
 
 .colorSwatch:hover {
   transform: scale(1.1);
+}
+
+.colorSwatch:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.colorSwatch:disabled:hover {
+  transform: none;
 }
 
 .colorSwatch.selected {

--- a/app/components/colors/colors.tsx
+++ b/app/components/colors/colors.tsx
@@ -4,6 +4,7 @@ import styles from './colors.module.css';
 interface ColorSelectorProps {
   selectedColor: string;
   onColorSelect: (color: string) => void;
+  disabled?: boolean;
 }
 
 interface ColorOption {
@@ -24,7 +25,7 @@ const commonColors: ColorOption[] = [
   { value: '#ffffff', label: 'White' }
 ];
 
-export const ColorSelector = ({ selectedColor, onColorSelect }: ColorSelectorProps) => {
+export const ColorSelector = ({ selectedColor, onColorSelect, disabled = false }: ColorSelectorProps) => {
   const [showColorWheel, setShowColorWheel] = useState(false);
 
   return (
@@ -34,6 +35,7 @@ export const ColorSelector = ({ selectedColor, onColorSelect }: ColorSelectorPro
         <button 
           onClick={() => setShowColorWheel(!showColorWheel)}
           className={styles.toggleButton}
+          disabled={disabled}
         >
           {showColorWheel ? 'Presets' : 'Color Wheel'}
         </button>
@@ -47,6 +49,7 @@ export const ColorSelector = ({ selectedColor, onColorSelect }: ColorSelectorPro
             onChange={(e) => onColorSelect(e.target.value)}
             className={styles.colorWheel}
             title="Choose a color"
+            disabled={disabled}
           />
         </>
       ) : (
@@ -59,6 +62,7 @@ export const ColorSelector = ({ selectedColor, onColorSelect }: ColorSelectorPro
             onClick={() => onColorSelect(color.value)}
             aria-label={`Select ${color.label}`}
             title={color.label}
+            disabled={disabled}
           />
         ))}
       </div>

--- a/app/components/navbar/navbar.tsx
+++ b/app/components/navbar/navbar.tsx
@@ -4,7 +4,7 @@ import { SignOut } from '../actions/signout';
 import { ManageProfile } from '../user/manage-profile';
 import { CaseImport } from './case-import/case-import';
 import { AuthContext } from '~/contexts/auth.context';
-import { getUserData } from '~/utils/data';
+import { getUserData, getNotesViewPermission, getNotesButtonTooltip } from '~/utils/data';
 import { type ImportResult, type ConfirmationImportResult } from '~/types';
 
 interface NavbarProps {
@@ -118,10 +118,26 @@ export const Navbar = ({
   const isCaseManagementActive = true;
   const isFileManagementActive = isFileMenuOpen || hasLoadedImage;
   const canOpenImageNotes = hasLoadedImage;
-  const isImageNotesReadOnly = isReadOnly || isCurrentImageConfirmed || isUploading;
   const isImageNotesActive = canOpenImageNotes;
   const canDeleteCurrentFile = hasLoadedImage && !isReadOnly;
   const isArchivedCase = Boolean(isReadOnly && archiveDetails?.archived);
+  
+  // Use centralized permission helper for notes
+  const notesPermission = getNotesViewPermission({
+    imageLoaded: hasLoadedImage,
+    isUploading: isUploading || false,
+    isCheckingConfirmation: false, // Navbar doesn't track this granularly
+    isReadOnlyCase: isReadOnly || false,
+    isArchivedCase: isArchivedCase,
+    isConfirmedImage: isCurrentImageConfirmed || false
+  });
+  
+  const imageNotesTitle = getNotesButtonTooltip(notesPermission, {
+    isReadOnlyCase: isReadOnly,
+    isArchivedCase: isArchivedCase,
+    isConfirmedImage: isCurrentImageConfirmed
+  });
+
   const caseExportLabel = isArchivedCase
     ? 'Export Archive'
     : isReadOnly
@@ -365,13 +381,7 @@ export const Navbar = ({
             className={`${styles.navSectionButton} ${isImageNotesActive ? styles.navSectionButtonActive : ''}`}
             disabled={!canOpenImageNotes}
             aria-pressed={isImageNotesActive}
-            title={
-              !hasLoadedImage
-                ? 'Load an image to enable image notes'
-                : isImageNotesReadOnly
-                  ? 'Image notes are view-only in this state'
-                    : undefined
-            }
+            title={imageNotesTitle}
             onClick={() => {
               onOpenImageNotes?.();
             }}

--- a/app/components/navbar/navbar.tsx
+++ b/app/components/navbar/navbar.tsx
@@ -117,8 +117,6 @@ export const Navbar = ({
   const disableLongRunningCaseActions = isUploading;
   const isCaseManagementActive = true;
   const isFileManagementActive = isFileMenuOpen || hasLoadedImage;
-  const canOpenImageNotes = hasLoadedImage;
-  const isImageNotesActive = canOpenImageNotes;
   const canDeleteCurrentFile = hasLoadedImage && !isReadOnly;
   const isArchivedCase = Boolean(isReadOnly && archiveDetails?.archived);
   
@@ -137,6 +135,9 @@ export const Navbar = ({
     isArchivedCase: isArchivedCase,
     isConfirmedImage: isCurrentImageConfirmed
   });
+
+  const canOpenImageNotes = notesPermission.canOpen;
+  const isImageNotesActive = canOpenImageNotes;
 
   const caseExportLabel = isArchivedCase
     ? 'Export Archive'
@@ -383,6 +384,10 @@ export const Navbar = ({
             aria-pressed={isImageNotesActive}
             title={imageNotesTitle}
             onClick={() => {
+              if (!notesPermission.canOpen) {
+                return;
+              }
+
               onOpenImageNotes?.();
             }}
           >

--- a/app/components/sidebar/cases/case-sidebar.tsx
+++ b/app/components/sidebar/cases/case-sidebar.tsx
@@ -11,7 +11,9 @@ import {
 import { 
   canUploadFile, 
   ensureCaseConfirmationSummary,
-  getCaseConfirmationSummary
+  getCaseConfirmationSummary,
+  getNotesViewPermission,
+  getNotesButtonTooltip
 } from '~/utils/data';
 import { type FileData } from '~/types';
 
@@ -28,7 +30,6 @@ interface CaseSidebarProps {
   isReadOnly?: boolean;
   isReviewOnlyCase?: boolean;
   isArchivedCase?: boolean;
-  isConfirmed?: boolean;
   confirmationSaveVersion?: number;
   selectedFileId?: string;
   isUploading?: boolean;
@@ -50,7 +51,6 @@ export const CaseSidebar = ({
   isReadOnly = false,
   isReviewOnlyCase = false,
   isArchivedCase = false,
-  isConfirmed = false,
   confirmationSaveVersion = 0,
   selectedFileId,
   isUploading = false,
@@ -238,27 +238,24 @@ const handleImageSelect = (file: FileData) => {
     selectedFileId && !selectedFileConfirmationState
   );
 
-  const isSelectedFileConfirmed =
-    isConfirmed || !!selectedFileConfirmationState?.isConfirmed;
+  const isSelectedFileConfirmed = !!selectedFileConfirmationState?.isConfirmed;
 
-  const isImageNotesDisabled =
-    !imageLoaded ||
-    isReadOnly ||
-    isSelectedFileConfirmed ||
-    isUploading ||
-    isCheckingSelectedFileConfirmation;
+  // Use centralized permission helper
+  const notesPermission = getNotesViewPermission({
+    imageLoaded,
+    isUploading,
+    isCheckingConfirmation: isCheckingSelectedFileConfirmation,
+    isReadOnlyCase: isReadOnly,
+    isArchivedCase: isArchivedCase,
+    isConfirmedImage: isSelectedFileConfirmed
+  });
 
-  const imageNotesTitle = isUploading
-    ? 'Cannot edit notes while uploading'
-    : isCheckingSelectedFileConfirmation
-    ? 'Checking confirmation status...'
-    : isSelectedFileConfirmed
-    ? 'Cannot edit notes for confirmed images'
-    : isReadOnly
-    ? 'Cannot edit notes for read-only cases'
-    : !imageLoaded
-    ? 'Select an image first'
-    : undefined;
+  const isImageNotesDisabled = !notesPermission.canOpen;
+  const imageNotesTitle = getNotesButtonTooltip(notesPermission, {
+    isReadOnlyCase: isReadOnly,
+    isArchivedCase: isArchivedCase,
+    isConfirmedImage: isSelectedFileConfirmed
+  });
 
   const showCaseExportButton = Boolean(currentCase && isReadOnly);
   const caseExportButtonLabel = isArchivedCase ? 'Export Archive' : 'Export Confirmations';

--- a/app/components/sidebar/notes/notes-editor-form.tsx
+++ b/app/components/sidebar/notes/notes-editor-form.tsx
@@ -154,7 +154,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
   const [savedSnapshot, setSavedSnapshot] = useState<string>('');
   const [hasLoadedSnapshot, setHasLoadedSnapshot] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
-  const areEditsDisabled = isUploading || isReadOnly;
+  const areEditsDisabled = isUploading || isReadOnly || isConfirmedImage;
   const isReadOnlyMode = isConfirmedImage || isReadOnly;
   const canOpenModals = !isUploading;
 
@@ -753,6 +753,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
           <ColorSelector
             selectedColor={caseFontColor}
             onColorSelect={setCaseFontColor}
+            disabled={areEditsDisabled}
           />
         </div>
           </>
@@ -895,6 +896,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
             <ColorSelector
               selectedColor={indexColor}
               onColorSelect={setIndexColor}
+              disabled={areEditsDisabled}
             />            
           ) : null}
         </div>

--- a/app/components/sidebar/notes/notes-editor-form.tsx
+++ b/app/components/sidebar/notes/notes-editor-form.tsx
@@ -154,7 +154,9 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
   const [savedSnapshot, setSavedSnapshot] = useState<string>('');
   const [hasLoadedSnapshot, setHasLoadedSnapshot] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
-  const areInputsDisabled = isUploading || isConfirmedImage || isReadOnly;
+  const areEditsDisabled = isUploading || isReadOnly;
+  const isReadOnlyMode = isConfirmedImage || isReadOnly;
+  const canOpenModals = !isUploading;
 
   const notificationHandler = useCallback((message: string, type: 'success' | 'error' | 'warning' = 'success') => {
     if (externalShowNotification) {
@@ -687,7 +689,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                 type="text"
                 value={leftCase}
                 onChange={(e) => setLeftCase(e.target.value)}
-                disabled={useCurrentCaseLeft || areInputsDisabled}                
+                disabled={useCurrentCaseLeft || areEditsDisabled}                
               />
             </div>
             <label className={`${styles.checkboxLabel} mb-4`}>
@@ -696,7 +698,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                 checked={useCurrentCaseLeft}
                 onChange={(e) => setUseCurrentCaseLeft(e.target.checked)}
                 className={styles.checkbox}
-                disabled={areInputsDisabled}
+                disabled={areEditsDisabled}
               />
               <span>Use current case number</span>
             </label>            
@@ -707,7 +709,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                 type="text"
                 value={leftItem}
                 onChange={(e) => setLeftItem(e.target.value)}
-                disabled={areInputsDisabled}
+                disabled={areEditsDisabled}
               />
             </div>
           </div>
@@ -720,7 +722,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                 type="text"
                 value={rightCase}
                 onChange={(e) => setRightCase(e.target.value)}
-                disabled={useCurrentCaseRight || areInputsDisabled}                
+                disabled={useCurrentCaseRight || areEditsDisabled}                
               />
             </div>
             <label className={`${styles.checkboxLabel} mb-4`}>
@@ -729,7 +731,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                 checked={useCurrentCaseRight}
                 onChange={(e) => setUseCurrentCaseRight(e.target.checked)}
                 className={styles.checkbox}
-                disabled={areInputsDisabled}
+                disabled={areEditsDisabled}
               />
               <span>Use current case number</span>
             </label>
@@ -740,7 +742,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                 type="text"
                 value={rightItem}
                 onChange={(e) => setRightItem(e.target.value)}
-                disabled={areInputsDisabled}
+                disabled={areEditsDisabled}
               />
             </div>            
           </div>
@@ -795,7 +797,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                     value={getSelectedItemData().itemType}
                     onChange={(e) => setSelectedItemData({ itemType: e.target.value as ItemType })}
                     className={styles.select}
-                    disabled={areInputsDisabled}
+                    disabled={areEditsDisabled}
                   >
                     <option value="">Select item type...</option>
                     <option value="Bullet">Bullet</option>
@@ -810,7 +812,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                       value={getSelectedItemData().customClass}
                       onChange={(e) => setSelectedItemData({ customClass: e.target.value })}
                       placeholder="Specify object type"
-                      disabled={areInputsDisabled}
+                      disabled={areEditsDisabled}
                     />
                   )}
 
@@ -819,7 +821,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                     onChange={(e) => setSelectedItemData({ classNote: e.target.value })}
                     placeholder="Enter item details..."
                     className={styles.textarea}
-                    disabled={areInputsDisabled}
+                    disabled={areEditsDisabled}
                   />
                 </div>
             </div>
@@ -838,7 +840,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                     checked={getSelectedItemData().hasSubclass}
                     onChange={(e) => setSelectedItemData({ hasSubclass: e.target.checked })}
                     className={styles.checkbox}
-                    disabled={areInputsDisabled}
+                    disabled={areEditsDisabled}
                   />
                   <span>Potential subclass?</span>
                 </label>
@@ -866,7 +868,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                 type="radio"
                 checked={indexType === 'color'}
                 onChange={() => setIndexType('color')}
-                disabled={areInputsDisabled}
+                disabled={areEditsDisabled}
               />
               <span>Color</span>
             </label>
@@ -875,7 +877,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                 type="radio"
                 checked={indexType === 'number'}
                 onChange={() => setIndexType('number')}
-                disabled={areInputsDisabled}
+                disabled={areEditsDisabled}
               />
               <span>Number/Letter</span>
             </label>
@@ -887,7 +889,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
               value={indexNumber}
               onChange={(e) => setIndexNumber(e.target.value)}
               placeholder="Enter index number"
-              disabled={areInputsDisabled}
+              disabled={areEditsDisabled}
             />
           ) : indexType === 'color' ? (            
             <ColorSelector
@@ -926,7 +928,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                   }
                 }}
                 className={styles.select}
-                disabled={areInputsDisabled}
+                disabled={areEditsDisabled}
               >
                 <option value="">Select support level...</option>
                 <option value="ID">Identification</option>
@@ -939,7 +941,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
                   checked={includeConfirmation}
                   onChange={(e) => setIncludeConfirmation(e.target.checked)}
                   className={styles.checkbox}
-                  disabled={areInputsDisabled}
+                  disabled={areEditsDisabled}
                 />
                 <span>Include confirmation field</span>
               </label>
@@ -953,7 +955,8 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
           <button 
             onClick={() => setIsModalOpen(true)}
             className={styles.notesButton}
-            title={isConfirmedImage ? "Cannot edit notes for confirmed images" : isUploading ? "Cannot add notes while uploading" : undefined}
+            disabled={!canOpenModals}
+            title={isUploading ? "Cannot open notes while uploading" : undefined}
           >
             Additional Notes
           </button>
@@ -963,8 +966,8 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
           <button 
               onClick={handleSave}
               className={styles.saveButton}
-              disabled={areInputsDisabled}
-              title={isConfirmedImage ? "Cannot save notes for confirmed images" : isUploading ? "Cannot save notes while uploading" : undefined}
+              disabled={areEditsDisabled}
+              title={isConfirmedImage ? "Cannot save notes - image is confirmed" : isUploading ? "Cannot save notes while uploading" : isReadOnly ? "Cannot save notes - case is read-only" : undefined}
             >
               Save Notes
             </button>
@@ -974,13 +977,13 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
         onClose={() => setIsModalOpen(false)}
         notes={additionalNotes}
         onSave={(notes) => {
-          if (areInputsDisabled) {
+          if (areEditsDisabled) {
             return;
           }
 
           setAdditionalNotes(notes);
         }}
-        isReadOnly={areInputsDisabled}
+        isReadOnly={isReadOnlyMode}
         showNotification={notificationHandler}
       />
       <ItemDetailsModal
@@ -991,7 +994,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
         cartridgeCaseData={getSelectedItemData().cartridgeCaseData}
         shotshellData={getSelectedItemData().shotshellData}
         onSave={(b, c, s) => {
-          if (areInputsDisabled) {
+          if (areEditsDisabled) {
             return;
           }
 
@@ -1010,7 +1013,7 @@ export const NotesEditorForm = ({ currentCase, user, imageId, onAnnotationRefres
           }
         }}
         showNotification={notificationHandler}
-        isReadOnly={areInputsDisabled}
+        isReadOnly={isReadOnlyMode}
       />
       </>
         )}

--- a/app/components/sidebar/sidebar-container.tsx
+++ b/app/components/sidebar/sidebar-container.tsx
@@ -26,7 +26,6 @@ interface SidebarContainerProps {
   isReadOnly?: boolean;
   isReviewOnlyCase?: boolean;
   isArchivedCase?: boolean;
-  isConfirmed?: boolean;
   confirmationSaveVersion?: number;
   isUploading?: boolean;
   onUploadStatusChange?: (isUploading: boolean) => void;

--- a/app/components/sidebar/sidebar.tsx
+++ b/app/components/sidebar/sidebar.tsx
@@ -22,7 +22,6 @@ interface SidebarProps {
   isReadOnly?: boolean;
   isReviewOnlyCase?: boolean;
   isArchivedCase?: boolean;
-  isConfirmed?: boolean;
   confirmationSaveVersion?: number;
   isUploading?: boolean;
   onUploadStatusChange?: (isUploading: boolean) => void;
@@ -43,7 +42,6 @@ export const Sidebar = ({
   isReadOnly = false,
   isReviewOnlyCase = false,
   isArchivedCase = false,
-  isConfirmed = false,
   confirmationSaveVersion = 0,
   isUploading: initialIsUploading = false,
   onUploadStatusChange,
@@ -93,7 +91,6 @@ export const Sidebar = ({
         isReadOnly={isReadOnly}
         isReviewOnlyCase={isReviewOnlyCase}
         isArchivedCase={isArchivedCase}
-        isConfirmed={isConfirmed}
         confirmationSaveVersion={confirmationSaveVersion}
         selectedFileId={imageId}
         isUploading={isUploading}

--- a/app/routes/striae/striae.tsx
+++ b/app/routes/striae/striae.tsx
@@ -746,10 +746,10 @@ export const Striae = ({ user }: StriaePage) => {
   const isCurrentImageConfirmed = hasLoadedImage && !!annotationData?.confirmationData;
 
   useEffect(() => {
-    if (showNotes && (!hasLoadedImage || isCurrentImageConfirmed)) {
+    if (showNotes && !hasLoadedImage) {
       setShowNotes(false);
     }
-  }, [showNotes, hasLoadedImage, isCurrentImageConfirmed]);
+  }, [showNotes, hasLoadedImage]);
 
   // Automatic save handler for annotation updates
   const handleAnnotationUpdate = async (data: AnnotationData) => {
@@ -868,7 +868,6 @@ export const Striae = ({ user }: StriaePage) => {
           isReadOnly={isReadOnlyCase}
           isReviewOnlyCase={isReviewOnlyCase}
           isArchivedCase={archiveDetails.archived}
-          isConfirmed={!!annotationData?.confirmationData}
           confirmationSaveVersion={confirmationSaveVersion}
           isUploading={isUploading}
           onUploadStatusChange={setIsUploading}

--- a/app/utils/data/permissions.ts
+++ b/app/utils/data/permissions.ts
@@ -27,6 +27,16 @@ export interface CaseMetadata {
 }
 
 /**
+ * Result for notes viewing permissions
+ * Determines if notes can be viewed and in what mode (edit or view-only)
+ */
+export interface NotesViewPermission {
+  canOpen: boolean;        // Can the notes panel be opened
+  isReadOnly: boolean;     // Are notes in read-only mode (can view but not edit)
+  reason?: string;         // Reason if notes cannot be opened
+}
+
+/**
  * Get user data from KV store
  */
 export const getUserData = async (user: User): Promise<UserData | null> => {
@@ -565,4 +575,117 @@ export const removeUserCase = async (user: User, caseNumber: string): Promise<vo
     console.error('Error removing case from user:', error);
     throw error;
   }
+};
+
+// ============================================================================
+// NOTES VIEW PERMISSIONS
+// ============================================================================
+
+/**
+ * Determine if notes can be opened and viewed, and whether they should be in read-only mode
+ * 
+ * Notes can be viewed in the following scenarios:
+ * - Normal active case with unconfirmed image: Can edit and save
+ * - Active case with confirmed image: Can view only (read-only)
+ * - Read-only case (review/confirmation case): Can view only (read-only)
+ * - Archived case: Can view only (read-only)
+ * 
+ * Notes cannot be opened when:
+ * - Files are uploading
+ * - Confirmation status is still being checked
+ * - No image is loaded
+ * 
+ * @param config Configuration object with state flags
+ * @returns NotesViewPermission object indicating if notes can be opened and if they're read-only
+ */
+export const getNotesViewPermission = (config: {
+  imageLoaded: boolean;
+  isUploading: boolean;
+  isCheckingConfirmation: boolean;
+  isReadOnlyCase?: boolean;
+  isArchivedCase?: boolean;
+  isConfirmedImage?: boolean;
+}): NotesViewPermission => {
+  const {
+    imageLoaded,
+    isUploading,
+    isCheckingConfirmation,
+    isReadOnlyCase = false,
+    isArchivedCase = false,
+    isConfirmedImage = false
+  } = config;
+
+  // Cannot open if uploading files
+  if (isUploading) {
+    return {
+      canOpen: false,
+      isReadOnly: false,
+      reason: 'Cannot open notes while uploading'
+    };
+  }
+
+  // Cannot open if checking confirmation status
+  if (isCheckingConfirmation) {
+    return {
+      canOpen: false,
+      isReadOnly: false,
+      reason: 'Checking confirmation status...'
+    };
+  }
+
+  // Cannot open if no image is loaded
+  if (!imageLoaded) {
+    return {
+      canOpen: false,
+      isReadOnly: false,
+      reason: 'Select an image first'
+    };
+  }
+
+  // Can open, determine if read-only
+  const isReadOnly = isConfirmedImage || isReadOnlyCase || isArchivedCase;
+
+  return {
+    canOpen: true,
+    isReadOnly
+  };
+};
+
+/**
+ * Get a user-friendly tooltip message for the Image Notes button
+ * 
+ * This centralizes all the tooltip logic that appears in the navbar and sidebar
+ * 
+ * @param permission NotesViewPermission object from getNotesViewPermission
+ * @param additionalContext Optional context for more specific messages
+ * @returns Tooltip string, or undefined if button has no specific tooltip
+ */
+export const getNotesButtonTooltip = (
+  permission: NotesViewPermission,
+  additionalContext?: {
+    isReadOnlyCase?: boolean;
+    isArchivedCase?: boolean;
+    isConfirmedImage?: boolean;
+  }
+): string | undefined => {
+  // If cannot open, return the reason
+  if (!permission.canOpen) {
+    return permission.reason;
+  }
+
+  // Can open - provide context-specific read-only messages
+  if (permission.isReadOnly && additionalContext) {
+    if (additionalContext.isConfirmedImage) {
+      return 'Image notes: viewing only (image is confirmed)';
+    }
+    if (additionalContext.isReadOnlyCase) {
+      return 'Image notes: viewing only (case is read-only)';
+    }
+    if (additionalContext.isArchivedCase) {
+      return 'Image notes: viewing only (case is archived)';
+    }
+  }
+
+  // No tooltip needed for normal edit mode
+  return undefined;
 };

--- a/workers/audit-worker/wrangler.jsonc.example
+++ b/workers/audit-worker/wrangler.jsonc.example
@@ -7,7 +7,7 @@
   "name": "AUDIT_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/audit-worker.ts",
-  "compatibility_date": "2026-04-14",
+  "compatibility_date": "2026-04-15",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/data-worker/wrangler.jsonc.example
+++ b/workers/data-worker/wrangler.jsonc.example
@@ -5,7 +5,7 @@
   "name": "DATA_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/data-worker.ts",
-  "compatibility_date": "2026-04-14",
+  "compatibility_date": "2026-04-15",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/image-worker/wrangler.jsonc.example
+++ b/workers/image-worker/wrangler.jsonc.example
@@ -2,7 +2,7 @@
   "name": "IMAGES_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/image-worker.ts",
-  "compatibility_date": "2026-04-14",
+  "compatibility_date": "2026-04-15",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/pdf-worker/wrangler.jsonc.example
+++ b/workers/pdf-worker/wrangler.jsonc.example
@@ -2,7 +2,7 @@
   "name": "PDF_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/pdf-worker.ts",
-  "compatibility_date": "2026-04-14",
+  "compatibility_date": "2026-04-15",
   "compatibility_flags": [
     "nodejs_compat"
   ],

--- a/workers/user-worker/wrangler.jsonc.example
+++ b/workers/user-worker/wrangler.jsonc.example
@@ -2,7 +2,7 @@
   "name": "USER_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/user-worker.ts",
-  "compatibility_date": "2026-04-14",
+  "compatibility_date": "2026-04-15",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -1,6 +1,6 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "PAGES_PROJECT_NAME"
-compatibility_date = "2026-04-14"
+compatibility_date = "2026-04-15"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./build/client"
 


### PR DESCRIPTION
This pull request introduces a centralized and consistent approach for managing permissions and UI states related to image notes across the application. The main improvements include refactoring how the UI determines when notes can be viewed or edited, removing redundant props, and ensuring that tooltips and disabled states are handled uniformly.

**Centralized Notes Permissions and Tooltips**

- Replaced scattered logic for enabling/disabling image notes and related tooltips with the new `getNotesViewPermission` and `getNotesButtonTooltip` helpers throughout the `Navbar` and `CaseSidebar` components, ensuring consistent permission checks and user feedback. [[1]](diffhunk://#diff-170c07400f3cd1a96da61b4cbe57ddc4dc65585e1bee4d9270a2ffc5b82de286L7-R7) [[2]](diffhunk://#diff-170c07400f3cd1a96da61b4cbe57ddc4dc65585e1bee4d9270a2ffc5b82de286L121-R140) [[3]](diffhunk://#diff-170c07400f3cd1a96da61b4cbe57ddc4dc65585e1bee4d9270a2ffc5b82de286L368-R384) [[4]](diffhunk://#diff-2c659bc7b556cebb90e039cae37462884e1b78562ddc062d7ecb6b48c7d5ff9dL14-R16) [[5]](diffhunk://#diff-2c659bc7b556cebb90e039cae37462884e1b78562ddc062d7ecb6b48c7d5ff9dL241-R258)

**Component Prop and State Cleanup**

- Removed the unnecessary `isConfirmed` prop from `CaseSidebar`, `SidebarContainer`, and related usages, relying instead on confirmation state from file data or centralized permission helpers. [[1]](diffhunk://#diff-2c659bc7b556cebb90e039cae37462884e1b78562ddc062d7ecb6b48c7d5ff9dL31) [[2]](diffhunk://#diff-2c659bc7b556cebb90e039cae37462884e1b78562ddc062d7ecb6b48c7d5ff9dL53) [[3]](diffhunk://#diff-5baac56dcd806d06ba58691712849f757640fd3bea3141f7e2b4c4f41d071c3dL29)

**Notes Editor Form Logic Refinement**

- Refactored the `NotesEditorForm` to use new `areEditsDisabled` and `isReadOnlyMode` variables, clarifying when editing is allowed versus when the form is in read-only mode. This change also ensures modal dialogs and save actions respect the new permission logic. [[1]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L157-R159) [[2]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L690-R692) [[3]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L699-R701) [[4]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L710-R712) [[5]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L723-R725) [[6]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L732-R734) [[7]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L743-R745) [[8]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L798-R800) [[9]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L813-R815) [[10]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L822-R824) [[11]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L841-R843) [[12]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L869-R871) [[13]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L878-R880) [[14]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L890-R892) [[15]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L929-R931) [[16]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L942-R944) [[17]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L956-R959) [[18]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L966-R970) [[19]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L977-R986) [[20]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L994-R997) [[21]](diffhunk://#diff-a858fc14f2d01fbfd303032df5e5018172dd7aefad86afe60e30f6becd96a688L1013-R1016)

These changes improve maintainability, reduce duplication, and provide a better, more predictable user experience around image notes permissions.