### PR TITLE
fix confirmation-status cleanup for read-only case deletions

### DIFF
--- a/app/components/actions/case-import/storage-operations.ts
+++ b/app/components/actions/case-import/storage-operations.ts
@@ -228,12 +228,27 @@ export async function deleteReadOnlyCase(user: User, caseNumber: string): Promis
     );
 
     if (caseResponse.status === 404) {
-      // No backing data object exists; only remove the case reference from user metadata.
-      const removedFromMetadata = await removeReadOnlyCase(user, caseNumber);
-      if (removedFromMetadata) {
-        await removeConfirmationSummary();
+      // No backing data object exists.
+      // Treat this as successful idempotent cleanup even if metadata was already removed.
+      try {
+        const removedFromMetadata = await removeReadOnlyCase(user, caseNumber);
+
+        if (!removedFromMetadata) {
+          console.info(
+            `Read-only case ${caseNumber} metadata was already absent during 404 cleanup.`
+          );
+        }
+      } catch (removeMetadataError) {
+        console.warn(
+          `Failed metadata cleanup for read-only case ${caseNumber} during 404 cleanup:`,
+          removeMetadataError
+        );
       }
-      return removedFromMetadata;
+
+      // Safe/idempotent cleanup; run regardless of metadata state.
+      await removeConfirmationSummary();
+
+      return true;
     }
 
     if (!caseResponse.ok) {

--- a/app/components/actions/case-import/storage-operations.ts
+++ b/app/components/actions/case-import/storage-operations.ts
@@ -2,6 +2,7 @@ import type { User } from 'firebase/auth';
 import { fetchDataApi } from '~/utils/api';
 import {
   getUserReadOnlyCases,
+  removeCaseConfirmationSummary,
   updateUserData,
   validateUserSession
 } from '~/utils/data';
@@ -206,6 +207,14 @@ export async function deleteReadOnlyCase(user: User, caseNumber: string): Promis
     );
   };
 
+  const removeConfirmationSummary = async (): Promise<void> => {
+    try {
+      await removeCaseConfirmationSummary(user, caseNumber);
+    } catch (summaryError) {
+      console.warn(`Failed to remove confirmation summary for case ${caseNumber}:`, summaryError);
+    }
+  };
+
   let caseDataDeleteHadFailure = false;
 
   try {
@@ -220,8 +229,11 @@ export async function deleteReadOnlyCase(user: User, caseNumber: string): Promis
 
     if (caseResponse.status === 404) {
       // No backing data object exists; only remove the case reference from user metadata.
-      await removeReadOnlyCase(user, caseNumber);
-      return true;
+      const removedFromMetadata = await removeReadOnlyCase(user, caseNumber);
+      if (removedFromMetadata) {
+        await removeConfirmationSummary();
+      }
+      return removedFromMetadata;
     }
 
     if (!caseResponse.ok) {
@@ -296,6 +308,8 @@ export async function deleteReadOnlyCase(user: User, caseNumber: string): Promis
       return false;
     }
 
+    await removeConfirmationSummary();
+
     if (caseDataDeleteHadFailure) {
       console.warn(
         `Read-only case ${caseNumber} removed from metadata with partial storage cleanup failures.`
@@ -311,6 +325,7 @@ export async function deleteReadOnlyCase(user: User, caseNumber: string): Promis
     try {
       const removedFromMetadata = await removeReadOnlyCase(user, caseNumber);
       if (removedFromMetadata) {
+        await removeConfirmationSummary();
         console.warn(
           `Read-only case ${caseNumber} removed from metadata during error fallback. ` +
           'Some backing storage may require manual cleanup.'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@react-router/cloudflare": "^7.14.1",
         "firebase": "^12.12.0",
-        "isbot": "^5.1.38",
+        "isbot": "^5.1.39",
         "jszip": "^3.10.1",
         "qrcode": "^1.5.4",
         "react": "^19.2.5",
@@ -7434,9 +7434,9 @@
       "license": "MIT"
     },
     "node_modules/isbot": {
-      "version": "5.1.38",
-      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.38.tgz",
-      "integrity": "sha512-Cus2702JamTNMEY4zTP+TShgq/3qzjvGcBC4XMOV45BLaxD4iUFENkqu7ZhFeSzwNsCSZLjnGlihDQznnpnEEA==",
+      "version": "5.1.39",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.39.tgz",
+      "integrity": "sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw==",
       "license": "Unlicense",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   "dependencies": {
     "@react-router/cloudflare": "^7.14.1",
     "firebase": "^12.12.0",
-    "isbot": "^5.1.38",
+    "isbot": "^5.1.39",
     "jszip": "^3.10.1",
     "qrcode": "^1.5.4",
     "react": "^19.2.5",

--- a/workers/audit-worker/wrangler.jsonc.example
+++ b/workers/audit-worker/wrangler.jsonc.example
@@ -7,7 +7,7 @@
   "name": "AUDIT_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/audit-worker.ts",
-  "compatibility_date": "2026-04-15",
+  "compatibility_date": "2026-04-16",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/data-worker/wrangler.jsonc.example
+++ b/workers/data-worker/wrangler.jsonc.example
@@ -5,7 +5,7 @@
   "name": "DATA_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/data-worker.ts",
-  "compatibility_date": "2026-04-15",
+  "compatibility_date": "2026-04-16",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/image-worker/wrangler.jsonc.example
+++ b/workers/image-worker/wrangler.jsonc.example
@@ -2,7 +2,7 @@
   "name": "IMAGES_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/image-worker.ts",
-  "compatibility_date": "2026-04-15",
+  "compatibility_date": "2026-04-16",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/pdf-worker/wrangler.jsonc.example
+++ b/workers/pdf-worker/wrangler.jsonc.example
@@ -2,7 +2,7 @@
   "name": "PDF_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/pdf-worker.ts",
-  "compatibility_date": "2026-04-15",
+  "compatibility_date": "2026-04-16",
   "compatibility_flags": [
     "nodejs_compat"
   ],

--- a/workers/user-worker/wrangler.jsonc.example
+++ b/workers/user-worker/wrangler.jsonc.example
@@ -2,7 +2,7 @@
   "name": "USER_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/user-worker.ts",
-  "compatibility_date": "2026-04-15",
+  "compatibility_date": "2026-04-16",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -1,6 +1,6 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "PAGES_PROJECT_NAME"
-compatibility_date = "2026-04-15"
+compatibility_date = "2026-04-16"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./build/client"
 


### PR DESCRIPTION
This pull request improves the cleanup process when deleting a read-only case by ensuring that any associated confirmation summary data is also removed. The changes add a new step to delete the confirmation summary in all relevant code paths, enhancing data consistency and preventing leftover artifacts.

**Enhancements to case deletion and cleanup:**

* Added a call to `removeCaseConfirmationSummary` in the `deleteReadOnlyCase` function to ensure confirmation summaries are deleted alongside case data.
* Implemented the `removeConfirmationSummary` helper function to handle confirmation summary deletion and log warnings if it fails.
* Updated all code paths in `deleteReadOnlyCase` to invoke `removeConfirmationSummary` after successfully removing a case reference from user metadata, including normal, partial failure, and fallback scenarios. [[1]](diffhunk://#diff-a4b6a066e01940c22330c7abff293e69fb5fe0b714e8a017c26389702b66a295L223-R236) [[2]](diffhunk://#diff-a4b6a066e01940c22330c7abff293e69fb5fe0b714e8a017c26389702b66a295R311-R312) [[3]](diffhunk://#diff-a4b6a066e01940c22330c7abff293e69fb5fe0b714e8a017c26389702b66a295R328)