### PR TITLE
fix annotation edit date bug

### DIFF
--- a/app/routes/striae/striae.tsx
+++ b/app/routes/striae/striae.tsx
@@ -729,7 +729,7 @@ export const Striae = ({ user }: StriaePage) => {
             supportLevel: notes.supportLevel || 'Inconclusive',
             includeConfirmation: notes.includeConfirmation ?? false,
             boxAnnotations: notes.boxAnnotations || [],
-            updatedAt: notes.updatedAt || new Date().toISOString()
+            updatedAt: notes.updatedAt || ''
           });
         } else {
           setAnnotationData(null);
@@ -794,6 +794,7 @@ export const Striae = ({ user }: StriaePage) => {
     const now = new Date().toISOString();
     const dataWithEarliestTimestamp: AnnotationData = {
       ...data,
+      updatedAt: now,
       earliestAnnotationTimestamp: resolveEarliestAnnotationTimestamp(
         data.earliestAnnotationTimestamp,
         annotationData?.earliestAnnotationTimestamp,


### PR DESCRIPTION
This pull request makes a minor adjustment to how annotation update timestamps are handled in the `Striae` component. The main change ensures that the `updatedAt` field is always set to a valid value when saving annotations and avoids defaulting to the current timestamp when loading existing data.

- Annotation timestamp handling:
  * When loading annotation data, the `updatedAt` field now defaults to an empty string (`''`) instead of the current timestamp if not present in the source data.
  * When saving annotation data, the `updatedAt` field is explicitly set to the current timestamp (`now`).