### PR TITLE
case operations bug fix

### DIFF
--- a/app/routes/auth/emailActionHandler.tsx
+++ b/app/routes/auth/emailActionHandler.tsx
@@ -20,7 +20,7 @@ interface EmailActionHandlerProps {
   lang: string | null;
 }
 
-type HandlerState = 'loading' | 'ready-reset' | 'success' | 'error' | 'unsupported';
+type HandlerState = 'loading' | 'ready-reset' | 'success' | 'error';
 
 const getUserAgent = (): string | undefined => {
   if (typeof navigator === 'undefined') {
@@ -168,16 +168,6 @@ export const EmailActionHandler = ({ mode, oobCode, continueUrl, lang }: EmailAc
           setState('error');
         }
 
-        return;
-      }
-
-      if (mode === 'recoverEmail') {
-        if (!isMounted) {
-          return;
-        }
-
-        setState('unsupported');
-        setError('Email change recovery is not supported for Striae accounts.');
         return;
       }
 
@@ -378,7 +368,7 @@ export const EmailActionHandler = ({ mode, oobCode, continueUrl, lang }: EmailAc
           </form>
         )}
 
-        {(state === 'success' || state === 'error' || state === 'unsupported') && (
+        {(state === 'success' || state === 'error') && (
           <div className={styles.actions}>
             {showContinueButton && (
               <button

--- a/app/routes/auth/login.tsx
+++ b/app/routes/auth/login.tsx
@@ -28,9 +28,7 @@ import { generateUniqueId } from '~/utils/common';
 import { evaluatePasswordPolicy, buildActionCodeSettings, userHasMFA } from '~/utils/auth';
 import type { UserData } from '~/types';
 
-const DEMO_COMPANY_NAME = 'STRIAE DEMO';
-
-const SUPPORTED_EMAIL_ACTION_MODES = new Set(['resetPassword', 'verifyEmail', 'recoverEmail']);
+const SUPPORTED_EMAIL_ACTION_MODES = new Set(['resetPassword', 'verifyEmail']);
 
 const getUserFirstName = (user: User): string => {
   const displayName = user.displayName?.trim();
@@ -69,7 +67,7 @@ export const Login = () => {
   const [isClient, setIsClient] = useState(false);
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
-  const [company, setCompany] = useState(DEMO_COMPANY_NAME);
+  const [company, setCompany] = useState('');
   const [badgeId, setBadgeId] = useState('');
   const [confirmPasswordValue, setConfirmPasswordValue] = useState('');
   

--- a/app/utils/data/permissions.ts
+++ b/app/utils/data/permissions.ts
@@ -550,6 +550,8 @@ export const addUserCase = async (user: User, caseData: CaseMetadata): Promise<v
       const errorText = await response.text();
       throw new Error(`Failed to add case to user: ${response.status} - ${errorText}`);
     }
+
+    invalidateUserDataCache(user.uid);
     
   } catch (error) {
     console.error('Error adding case to user:', error);

--- a/app/utils/data/permissions.ts
+++ b/app/utils/data/permissions.ts
@@ -597,6 +597,8 @@ export const removeUserCase = async (user: User, caseNumber: string): Promise<vo
       const errorText = await response.text();
       throw new Error(`Failed to remove case from user: ${response.status} - ${errorText}`);
     }
+
+    invalidateUserDataCache(user.uid);
     
   } catch (error) {
     console.error('Error removing case from user:', error);


### PR DESCRIPTION
This pull request primarily removes support for the "recoverEmail" email action mode across the authentication flow, and introduces cache invalidation after user case modifications. The most important changes are grouped below by theme.

**Removal of "recoverEmail" support:**
* The "recoverEmail" mode is no longer included in the set of supported email action modes in `login.tsx`, and all related handling logic has been removed from `emailActionHandler.tsx`. This means users can no longer initiate or process email recovery actions in the application. [[1]](diffhunk://#diff-a590c0285efcfca91901399d8a53a96694db7d30243c558da27f4b049caec365L31-R31) [[2]](diffhunk://#diff-6b7341814d0083843c33c6ed76d5cead85052c1c6094d221d24c8d38e451752cL23-R23) [[3]](diffhunk://#diff-6b7341814d0083843c33c6ed76d5cead85052c1c6094d221d24c8d38e451752cL174-L183) [[4]](diffhunk://#diff-6b7341814d0083843c33c6ed76d5cead85052c1c6094d221d24c8d38e451752cL381-R371)
* The UI for the "unsupported" handler state has been removed, reflecting that this state is no longer possible. [[1]](diffhunk://#diff-6b7341814d0083843c33c6ed76d5cead85052c1c6094d221d24c8d38e451752cL23-R23) [[2]](diffhunk://#diff-6b7341814d0083843c33c6ed76d5cead85052c1c6094d221d24c8d38e451752cL381-R371)

**User data cache invalidation:**
* The `invalidateUserDataCache` function is now called after adding or removing a user case, ensuring that any cached user data is updated immediately after these operations. [[1]](diffhunk://#diff-598de1783664eb9ef56389af2dc84fc842bd80fdccaba7053c2390e2a6ffa578R554-R555) [[2]](diffhunk://#diff-598de1783664eb9ef56389af2dc84fc842bd80fdccaba7053c2390e2a6ffa578R601-R602)

**Minor state initialization update:**
* The default value for the `company` state in the login form has been changed from a demo value to an empty string.