### PR TITLE
allow deletion of currently loaded case in all cases modal

### DIFF
--- a/app/components/navbar/case-modals/all-cases-modal.tsx
+++ b/app/components/navbar/case-modals/all-cases-modal.tsx
@@ -33,6 +33,7 @@ interface CasesModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSelectCase: (caseNum: string) => void;
+  onCurrentCaseDeleted?: () => void;
   currentCase: string;
   user: User;
   confirmationSaveVersion?: number;
@@ -64,6 +65,7 @@ export const CasesModal = ({
   isOpen,
   onClose,
   onSelectCase,
+  onCurrentCaseDeleted,
   currentCase,
   user,
   confirmationSaveVersion = 0,
@@ -224,16 +226,14 @@ export const CasesModal = ({
   );
 
   const canDeleteSelectedCase = Boolean(
-    selectedCase && selectedCase.caseNumber !== currentCase && !selectedCase.isReadOnly
+    selectedCase && !selectedCase.isReadOnly
   );
 
   const deleteSelectedCaseTitle = !selectedCase
     ? 'Select a case to delete.'
-    : selectedCase.caseNumber === currentCase
-      ? 'Open a different case before deleting this one.'
-      : selectedCase.isReadOnly
-        ? 'Read-only review cases cannot be deleted. Use Clear RO Case under Case Management first.'
-        : undefined;
+    : selectedCase.isReadOnly
+      ? 'Read-only review cases cannot be deleted here. Use Clear RO Case under Case Management first.'
+      : undefined;
 
   const effectiveFocusedIndex = paginatedCases.length === 0 ? 0 : Math.min(focusedIndex, paginatedCases.length - 1);
 
@@ -475,16 +475,13 @@ export const CasesModal = ({
 
   const handleDeleteSelectedCase = async () => {
     if (!selectedCase || !canDeleteSelectedCase) {
-      const isCurrentCaseSelection = selectedCase?.caseNumber === currentCase;
       const isReadOnlyReviewSelection = selectedCase?.isReadOnly === true;
 
       setActionNotice({
         type: 'warning',
-        message: isCurrentCaseSelection
-          ? 'Open a different case before deleting this one.'
-          : isReadOnlyReviewSelection
-            ? 'Read-only review cases cannot be deleted. Use Clear RO Case under Case Management first.'
-            : 'Selected case cannot be deleted.',
+        message: isReadOnlyReviewSelection
+          ? 'Read-only review cases cannot be deleted here. Use Clear RO Case under Case Management first.'
+          : 'Selected case cannot be deleted.',
       });
       return;
     }
@@ -506,10 +503,15 @@ export const CasesModal = ({
     setActionNotice(null);
 
     try {
+      const wasCurrentCase = selectedCase.caseNumber === currentCase;
       const deleteResult = await deleteCase(user, selectedCase.caseNumber);
       setSelectedCaseNumber(null);
       setIsDeleteModalOpen(false);
       setRefreshKey((k) => k + 1);
+
+      if (wasCurrentCase) {
+        onCurrentCaseDeleted?.();
+      }
 
       if (deleteResult.missingImages.length > 0) {
         setActionNotice({

--- a/app/routes/striae/striae.tsx
+++ b/app/routes/striae/striae.tsx
@@ -957,6 +957,7 @@ export const Striae = ({ user }: StriaePage) => {
         onSelectCase={(selectedCase) => {
           void loadCaseIntoWorkspace(selectedCase);
         }}
+        onCurrentCaseDeleted={clearLoadedCaseState}
         currentCase={currentCase || ''}
         user={user}
         confirmationSaveVersion={confirmationSaveVersion}


### PR DESCRIPTION
This pull request updates the case deletion logic in the `CasesModal` component to allow users to delete the currently open case and handle the UI state accordingly. It introduces a new callback for notifying when the current case is deleted, updates messages for read-only cases, and ensures the parent component can clear the loaded case state when needed.

**Case Deletion Behavior Updates:**

* Removed the restriction preventing deletion of the currently open case, so users can now delete it directly. [[1]](diffhunk://#diff-012dd356751568b7796f32b71ffe9905f1b114748271ed0cf6a17234c2b956f0L227-R235) [[2]](diffhunk://#diff-012dd356751568b7796f32b71ffe9905f1b114748271ed0cf6a17234c2b956f0L478-R483)
* Added an optional `onCurrentCaseDeleted` callback to `CasesModalProps` and called it when the current case is deleted, allowing parent components to respond appropriately (e.g., clearing loaded case state). [[1]](diffhunk://#diff-012dd356751568b7796f32b71ffe9905f1b114748271ed0cf6a17234c2b956f0R36) [[2]](diffhunk://#diff-012dd356751568b7796f32b71ffe9905f1b114748271ed0cf6a17234c2b956f0R68) [[3]](diffhunk://#diff-012dd356751568b7796f32b71ffe9905f1b114748271ed0cf6a17234c2b956f0R506-R515) [[4]](diffhunk://#diff-fc89c9692eee75e20d812029baddcd95c07f752029ce0f00c4fedcc899f3d9e5R960)

**User Feedback Improvements:**

* Updated warning messages for read-only cases to clarify that they cannot be deleted here and to direct users to use "Clear RO Case" under Case Management. [[1]](diffhunk://#diff-012dd356751568b7796f32b71ffe9905f1b114748271ed0cf6a17234c2b956f0L227-R235) [[2]](diffhunk://#diff-012dd356751568b7796f32b71ffe9905f1b114748271ed0cf6a17234c2b956f0L478-R483)