### PR TITLE
bump v6.1.7

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -22,6 +22,14 @@ Striae is a specialized, cloud-native platform designed to streamline forensic f
 
 ## 📋 Changelog
 
+## [2026-04-20] - *[Patch Release v6.1.7](https://github.com/striae-org/striae/releases/tag/v6.1.7)*
+
+- **🗑️ Case Deletion Fix** - Fixed a regression blocking deletion of the currently loaded case from the all-cases modal; any case can now be deleted from the modal regardless of which case is active.
+- **⚡ Data Cache Refresh Hardening** - Hardened the data cache refresh logic to handle edge cases that could leave stale entries after refresh operations.
+- **🐛 Case Listing Cache Reset** - Fixed the case listing cache not resetting correctly after a case deletion, preventing stale entries from persisting in the list.
+- **🔑 Case Creation/Rename Permissions Fix** - Resolved a bug where permission checks for case creation and rename operations incorrectly blocked valid users.
+- **🧹 Auth and Demo Logic Cleanup** - Removed unused demo company logic and the unimplemented `recoverEmail` email action handler, reducing dead code paths in the auth flow.
+
 ## [2026-04-19] - *[Patch Release v6.1.6](https://github.com/striae-org/striae/releases/tag/v6.1.6)*
 
 - **🔗 Sidebar Navigation Update** - Replaced the "Striae Community" link in the About & Support sidebar footer with a direct "Manage Membership" link pointing to the account management portal.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version     | Supported          |
 | ----------- | ------------------ |
-| v6.1.6  | :white_check_mark: |
+| v6.1.7  | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/.github/release-notes/RELEASE_NOTES_v6.1.7.md
+++ b/.github/release-notes/RELEASE_NOTES_v6.1.7.md
@@ -1,0 +1,48 @@
+# Striae Release Notes - v6.1.7
+
+**Release Date**: April 20, 2026
+**Period**: April 20, 2026 through April 20, 2026
+**Total Commits**: 5 (non-merge after the v6.1.6 bump)
+
+## Patch Release - Case Management Fixes, Data Cache Hardening, and Auth Cleanup
+
+## Summary
+
+v6.1.7 is a patch release that fixes a regression preventing deletion of the currently loaded case from the all-cases modal, hardens the data cache refresh flow, corrects cache reset behaviour on case deletions, resolves a case creation and rename permissions bug, and removes unused demo company logic and the `recoverEmail` email action handler that was never implemented.
+
+## Detailed Changes
+
+### Case Deletion Fix (All Cases Modal)
+
+- Fixed a regression that blocked deletion of the currently loaded case when triggered from the all-cases modal.
+- Users can now delete any case from the modal regardless of which case is currently open.
+
+### Data Cache Refresh Hardening
+
+- Hardened the data cache refresh logic to handle edge cases that could leave stale data in the cache after refresh operations.
+
+### Case Listing Cache Reset on Deletion
+
+- Fixed an issue where the case listing cache was not correctly reset after a case deletion, which could cause stale entries to persist in the list.
+
+### Case Creation and Rename Permissions Bug
+
+- Resolved a bug where permission checks for case creation and rename operations could incorrectly block valid users from performing these actions.
+
+### Auth and Demo Logic Cleanup
+
+- Removed unused demo company logic that was no longer applicable.
+- Removed the `recoverEmail` email action handler, which was never permitted or implemented.
+- This cleanup reduces dead code paths and potential confusion in the authentication flow.
+
+## Release Statistics
+
+- **Baseline**: `.github/release-notes/RELEASE_NOTES_v6.1.6.md`
+- **Commits Included**: 5 (non-merge commits after `bump v6.1.6` on 04/19/2026)
+- **Build Status**: Passed (`npm run build`)
+- **Typecheck Status**: Passed (`npm run typecheck`)
+- **Lint Status**: Passed with expected warnings in generated `worker-configuration.d.ts` files (`npm run lint`)
+
+## Closing Note
+
+v6.1.7 delivers a focused set of case management and cache reliability fixes, corrects a permissions regression affecting case creation and rename, and cleans up dead authentication code paths that were never intended for use in production.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@striae-org/striae",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@striae-org/striae",
-      "version": "6.1.6",
+      "version": "6.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-router/cloudflare": "^7.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@striae-org/striae",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "private": false,
   "description": "Striae is a specialized, cloud-native platform designed to streamline forensic firearms identification by providing an intuitive environment for digital comparison image annotation, authenticated confirmations, and automated report generation.",
   "license": "Apache-2.0",

--- a/workers/audit-worker/package-lock.json
+++ b/workers/audit-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audit-worker",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audit-worker",
-      "version": "6.1.6",
+      "version": "6.1.7",
       "devDependencies": {
         "wrangler": "^4.83.0"
       }

--- a/workers/audit-worker/package.json
+++ b/workers/audit-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-worker",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/audit-worker/wrangler.jsonc.example
+++ b/workers/audit-worker/wrangler.jsonc.example
@@ -7,7 +7,7 @@
   "name": "AUDIT_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/audit-worker.ts",
-  "compatibility_date": "2026-04-19",
+  "compatibility_date": "2026-04-20",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/data-worker/package-lock.json
+++ b/workers/data-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-worker",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "data-worker",
-      "version": "6.1.6",
+      "version": "6.1.7",
       "devDependencies": {
         "wrangler": "^4.83.0"
       }

--- a/workers/data-worker/package.json
+++ b/workers/data-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-worker",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/data-worker/wrangler.jsonc.example
+++ b/workers/data-worker/wrangler.jsonc.example
@@ -5,7 +5,7 @@
   "name": "DATA_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/data-worker.ts",
-  "compatibility_date": "2026-04-19",
+  "compatibility_date": "2026-04-20",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/image-worker/package-lock.json
+++ b/workers/image-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-worker",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-worker",
-      "version": "6.1.6",
+      "version": "6.1.7",
       "devDependencies": {
         "wrangler": "^4.83.0"
       }

--- a/workers/image-worker/package.json
+++ b/workers/image-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-worker",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/image-worker/wrangler.jsonc.example
+++ b/workers/image-worker/wrangler.jsonc.example
@@ -2,7 +2,7 @@
   "name": "IMAGES_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/image-worker.ts",
-  "compatibility_date": "2026-04-19",
+  "compatibility_date": "2026-04-20",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/pdf-worker/package-lock.json
+++ b/workers/pdf-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdf-worker",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-worker",
-      "version": "6.1.6",
+      "version": "6.1.7",
       "devDependencies": {
         "wrangler": "^4.83.0"
       }

--- a/workers/pdf-worker/package.json
+++ b/workers/pdf-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-worker",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "private": true,
   "scripts": {
     "generate:assets": "node scripts/generate-assets.js",

--- a/workers/pdf-worker/wrangler.jsonc.example
+++ b/workers/pdf-worker/wrangler.jsonc.example
@@ -2,7 +2,7 @@
   "name": "PDF_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/pdf-worker.ts",
-  "compatibility_date": "2026-04-19",
+  "compatibility_date": "2026-04-20",
   "compatibility_flags": [
     "nodejs_compat"
   ],

--- a/workers/user-worker/package-lock.json
+++ b/workers/user-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "user-worker",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "user-worker",
-      "version": "6.1.6",
+      "version": "6.1.7",
       "devDependencies": {
         "wrangler": "^4.83.0"
       }

--- a/workers/user-worker/package.json
+++ b/workers/user-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-worker",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/user-worker/wrangler.jsonc.example
+++ b/workers/user-worker/wrangler.jsonc.example
@@ -2,7 +2,7 @@
   "name": "USER_WORKER_NAME",
   "account_id": "ACCOUNT_ID",
   "main": "src/user-worker.ts",
-  "compatibility_date": "2026-04-19",
+  "compatibility_date": "2026-04-20",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -1,6 +1,6 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "PAGES_PROJECT_NAME"
-compatibility_date = "2026-04-19"
+compatibility_date = "2026-04-20"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./build/client"
 


### PR DESCRIPTION
This pull request releases Striae v6.1.7, a patch focused on fixing case management regressions, improving cache reliability, correcting permissions logic, and cleaning up dead authentication code. It also updates all relevant version numbers and compatibility dates across the codebase.

**Key changes in this release:**

### Case Management & Permissions

* Fixed a regression that blocked deletion of the currently loaded case from the all-cases modal; any case can now be deleted regardless of which is active. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R25-R32) [[2]](diffhunk://#diff-5aa962bae229cbeacc634f5800a7ba91898e5f07d3b5aa674c77d6bf58308c3dR1-R48)
* Fixed the case listing cache not resetting correctly after a case deletion, preventing stale entries from persisting. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R25-R32) [[2]](diffhunk://#diff-5aa962bae229cbeacc634f5800a7ba91898e5f07d3b5aa674c77d6bf58308c3dR1-R48)
* Resolved a bug where permission checks for case creation and rename operations incorrectly blocked valid users. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R25-R32) [[2]](diffhunk://#diff-5aa962bae229cbeacc634f5800a7ba91898e5f07d3b5aa674c77d6bf58308c3dR1-R48)

### Data Cache & Reliability

* Hardened the data cache refresh logic to handle edge cases that could leave stale entries after refresh operations. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R25-R32) [[2]](diffhunk://#diff-5aa962bae229cbeacc634f5800a7ba91898e5f07d3b5aa674c77d6bf58308c3dR1-R48)

### Authentication & Code Cleanup

* Removed unused demo company logic and the unimplemented `recoverEmail` email action handler, reducing dead code paths in the auth flow. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R25-R32) [[2]](diffhunk://#diff-5aa962bae229cbeacc634f5800a7ba91898e5f07d3b5aa674c77d6bf58308c3dR1-R48)

### Versioning & Configuration

* Bumped version numbers to `6.1.7` in all relevant `package.json`, `package-lock.json`, and worker configuration files. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L3-R9) [[3]](diffhunk://#diff-d16fb6b09f684160054b5c0e353e35f63f00651bc94bcbcaf521437dfccd9fc9L3-R3) [[4]](diffhunk://#diff-6e5e36a60c0d36c5b64aa73374f62c57efbd072023660e8d0aec12a4280248c9L3-R9) [[5]](diffhunk://#diff-25a913066a7fe613d4b06888c5c4429d3115d670e3a47c1e0093f93ac69b0bc6L3-R3) [[6]](diffhunk://#diff-8aaa33f9d5640156d7cec29c58ba66ec9c932b4c106dc397b9558af952100cebL3-R9) [[7]](diffhunk://#diff-6b488296f955b235077b13eb5a4be1d4fbec35413644445e150b93f1800aec71L3-R3) [[8]](diffhunk://#diff-1d4408399474dc9865a67a3928dc47144f925b807fcb91fff6d733905d621e66L3-R9) [[9]](diffhunk://#diff-0e896c71a77804a30199ade801c401da5f6343c86e21a0e184974feb2a80a941L3-R3) [[10]](diffhunk://#diff-4f2f3beba65f88db2a2cf66fe5915d9f3fd6d730ef00036a75bf9c3d11c2dc7bL3-R9) [[11]](diffhunk://#diff-0c2ca2d4f71077b08e99fbcf3b51ff4afd93456ac56a1cfa279ef8ce62e9b445L3-R3)
* Updated `compatibility_date` to `2026-04-20` in all worker and project configuration files. [[1]](diffhunk://#diff-1a6087ffb2a3e27bd4d44cde8f8c758f6898e55de22ae50959d430ffb241bb5dL10-R10) [[2]](diffhunk://#diff-a06bd34d808c6d17bced83f7809fdc3cc67dbd9e9660d6fca84465f89b3c3d28L8-R8) [[3]](diffhunk://#diff-e1d3129c96b6720c42ba1122071136b06284163dfb6f166c78e23c298d5ab0a1L5-R5) [[4]](diffhunk://#diff-4645a382213755d06092c726a199073136b1ffd843a8581bb127b509e90783b9L5-R5) [[5]](diffhunk://#diff-2f63fd80985909733991b5f726934a04b6247e849aab2946763e8d1b55eba4ebL5-R5) [[6]](diffhunk://#diff-f46aecc9ef219c92b725dba6fc747384927016bcfe870946334f587d145e1454L3-R3)
* Updated `.github/SECURITY.md` to reflect support for v6.1.7.

For more details, see the release notes in `.github/release-notes/RELEASE_NOTES_v6.1.7.md`.