### PR TITLE
bump v6.1.8

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -20,6 +20,13 @@ Striae is a specialized, cloud-native platform designed to streamline forensic f
 
 ## 📋 Changelog
 
+## [2026-04-20] - *[Patch Release v6.1.8](https://github.com/striae-org/striae/releases/tag/v6.1.8)*
+
+- **🧹 Worker CORS Cleanup** - Removed CORS configuration from all worker entry points and consolidated worker source files by renaming `.example.ts` files to canonical `.ts` files; refactored user worker routes and removed CORS scaffolding from deploy config scripts.
+- **🧪 Unit Test Suite Expansion** - Added app-level tests for forensics operations (confirmation signing, export encryption, manifest signing, audit export signing) and confirmation summary data, plus worker-level data utility tests (encryption, signature, and signing payload utils).
+- **🔗 Community Links Removal** - Removed community links from `.github/README.md` and `README.md`.
+- **⚙️ Maintenance** - Updated `.gitignore`, removed leftover output files, and applied lint fixes across `eslint.config.js`, worker test files, and `README.md`.
+
 ## [2026-04-20] - *[Patch Release v6.1.7](https://github.com/striae-org/striae/releases/tag/v6.1.7)*
 
 - **🗑️ Case Deletion Fix** - Fixed a regression blocking deletion of the currently loaded case from the all-cases modal; any case can now be deleted from the modal regardless of which case is active.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version     | Supported          |
 | ----------- | ------------------ |
-| v6.1.7  | :white_check_mark: |
+| v6.1.8  | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/.github/release-notes/RELEASE_NOTES_v6.1.8.md
+++ b/.github/release-notes/RELEASE_NOTES_v6.1.8.md
@@ -1,0 +1,49 @@
+# Striae Release Notes - v6.1.8
+
+**Release Date**: April 20, 2026
+**Period**: April 20, 2026 through April 20, 2026
+**Total Commits**: 9 (non-merge after the v6.1.7 bump)
+
+## Patch Release - Worker Cleanup, Test Suite Expansion, and Maintenance
+
+## Summary
+
+v6.1.8 is a patch release focused on worker code cleanup, consolidation of worker source files, expansion of the unit test suite across app forensics and worker data layers, removal of community links from documentation, and general maintenance including gitignore, lint, and file cleanup.
+
+## Detailed Changes
+
+### Worker CORS Cleanup and Source File Consolidation
+
+- Removed CORS configuration from the audit, data, image, pdf, and user worker source files, simplifying worker entry points.
+- Renamed `.example.ts` worker files to canonical `.ts` source files across all workers, making them the authoritative source rather than templates.
+- Refactored user worker route handling to reduce CORS overhead and clean up route registration.
+- Removed the CORS scaffolding step from deploy configuration scripts.
+
+### Unit Test Suite Expansion
+
+- Added app-level unit tests covering forensics operations: confirmation signing, export encryption, manifest signing, and audit export signing.
+- Added app-level unit test for confirmation summary data operations.
+- Added worker-level unit tests for data worker utilities: encryption utils, signature utils, and signing payload utils.
+- Updated `tsconfig.json` to include the new test directories.
+
+### Community Links Removal
+
+- Removed community links from `.github/README.md` and `README.md`.
+
+### Maintenance
+
+- Updated `.gitignore` to reflect the removed E2E test infrastructure and output file patterns.
+- Removed empty `out.txt` and `output.txt` output files that were leftover from development.
+- Fixed lint issues in `eslint.config.js`, worker test files, and `README.md`.
+
+## Release Statistics
+
+- **Baseline**: `.github/release-notes/RELEASE_NOTES_v6.1.7.md`
+- **Commits Included**: 9 (non-merge commits after `bump v6.1.7` on 04/20/2026)
+- **Build Status**: Passed (`npm run build`)
+- **Typecheck Status**: Passed (`npm run typecheck`)
+- **Lint Status**: Passed with expected warnings in generated `worker-configuration.d.ts` files (`npm run lint`)
+
+## Closing Note
+
+v6.1.8 delivers targeted cleanup across the worker layer by removing CORS boilerplate and consolidating source files, expands automated test coverage for forensics and worker data utilities, and removes stale community references from documentation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@striae-org/striae",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@striae-org/striae",
-      "version": "6.1.7",
+      "version": "6.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-router/cloudflare": "^7.14.1",
@@ -19,6 +19,7 @@
         "react-router": "^7.14.1"
       },
       "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.14.8",
         "@react-router/dev": "^7.14.1",
         "@react-router/fs-routes": "^7.14.1",
         "@types/qrcode": "^1.5.6",
@@ -545,6 +546,35 @@
         "workerd": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.14.8.tgz",
+      "integrity": "sha512-A48YYGoJkJHMj5iTv1pK9LpiBWD5gK/cI5N1NmUYx+bVllfJL5LKGXPEp9CETlhQCTEa8XkSy0zjNf7KF/7LsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cjs-module-lexer": "^1.2.3",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260420.0",
+        "wrangler": "4.84.0",
+        "zod": "^3.25.76"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "^4.1.0",
+        "@vitest/snapshot": "^4.1.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
@@ -5357,6 +5387,13 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@striae-org/striae",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "private": false,
   "description": "Striae is a specialized, cloud-native platform designed to streamline forensic firearms identification by providing an intuitive environment for digital comparison image annotation, authenticated confirmations, and automated report generation.",
   "license": "Apache-2.0",
@@ -113,6 +113,7 @@
     "react-router": "^7.14.1"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.14.8",
     "@react-router/dev": "^7.14.1",
     "@react-router/fs-routes": "^7.14.1",
     "@types/qrcode": "^1.5.6",

--- a/tests/workers/data/signature-utils.test.ts
+++ b/tests/workers/data/signature-utils.test.ts
@@ -80,8 +80,8 @@ async function verifyRsaPss(
   return crypto.subtle.verify(
     { name: 'RSA-PSS', saltLength: 32 },
     key,
-    base64UrlToUint8Array(signatureBase64url),
-    new TextEncoder().encode(payload)
+    base64UrlToUint8Array(signatureBase64url) as BufferSource,
+    new TextEncoder().encode(payload) as BufferSource
   );
 }
 

--- a/workers/audit-worker/package-lock.json
+++ b/workers/audit-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audit-worker",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audit-worker",
-      "version": "6.1.7",
+      "version": "6.1.8",
       "devDependencies": {
         "wrangler": "^4.84.0"
       }

--- a/workers/audit-worker/package.json
+++ b/workers/audit-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-worker",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/data-worker/package-lock.json
+++ b/workers/data-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-worker",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "data-worker",
-      "version": "6.1.7",
+      "version": "6.1.8",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.14.8",
         "wrangler": "^4.84.0"

--- a/workers/data-worker/package.json
+++ b/workers/data-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-worker",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/image-worker/package-lock.json
+++ b/workers/image-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-worker",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-worker",
-      "version": "6.1.7",
+      "version": "6.1.8",
       "devDependencies": {
         "wrangler": "^4.84.0"
       }

--- a/workers/image-worker/package.json
+++ b/workers/image-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-worker",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/pdf-worker/package-lock.json
+++ b/workers/pdf-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdf-worker",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-worker",
-      "version": "6.1.7",
+      "version": "6.1.8",
       "devDependencies": {
         "wrangler": "^4.84.0"
       }

--- a/workers/pdf-worker/package.json
+++ b/workers/pdf-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-worker",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "private": true,
   "scripts": {
     "generate:assets": "node scripts/generate-assets.js",

--- a/workers/user-worker/package-lock.json
+++ b/workers/user-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "user-worker",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "user-worker",
-      "version": "6.1.7",
+      "version": "6.1.8",
       "devDependencies": {
         "wrangler": "^4.84.0"
       }

--- a/workers/user-worker/package.json
+++ b/workers/user-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-worker",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",


### PR DESCRIPTION
This pull request releases Striae version 6.1.8, focusing on cleanup of worker code, expansion of the unit test suite, removal of outdated community links from documentation, and general project maintenance. The update also bumps version numbers across all relevant packages and updates the security policy.

**Worker code cleanup and consolidation**
- Removed CORS configuration from all worker entry points and consolidated worker source files by renaming `.example.ts` files to canonical `.ts` files; also refactored user worker routes and removed CORS scaffolding from deploy config scripts. (.github/README.md [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R23-R29) .github/release-notes/RELEASE_NOTES_v6.1.8.md [[2]](diffhunk://#diff-566e199b22afed23bbd90e0db915dd398ffb4bf3a463111e9a518b8ddb682a33R1-R49)

**Testing improvements**
- Expanded the unit test suite with new app-level tests for forensics operations and confirmation summary data, as well as worker-level tests for data utilities such as encryption and signature utilities. (.github/README.md [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R23-R29) .github/release-notes/RELEASE_NOTES_v6.1.8.md [[2]](diffhunk://#diff-566e199b22afed23bbd90e0db915dd398ffb4bf3a463111e9a518b8ddb682a33R1-R49) package.json [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R116) tests/workers/data/signature-utils.test.ts [[4]](diffhunk://#diff-23cb45df948bfb2e469c51e04090502017e3324b931b6b6d57f608968a4d5fa0L83-R84)

**Documentation and community**
- Removed community links from `.github/README.md` and `README.md` to keep documentation up-to-date. (.github/README.md [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R23-R29) .github/release-notes/RELEASE_NOTES_v6.1.8.md [[2]](diffhunk://#diff-566e199b22afed23bbd90e0db915dd398ffb4bf3a463111e9a518b8ddb682a33R1-R49)

**Maintenance and housekeeping**
- Updated `.gitignore`, removed leftover output files, and applied lint fixes across configuration and test files. (.github/README.md [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R23-R29) .github/release-notes/RELEASE_NOTES_v6.1.8.md [[2]](diffhunk://#diff-566e199b22afed23bbd90e0db915dd398ffb4bf3a463111e9a518b8ddb682a33R1-R49)

**Version bumps and metadata**
- Bumped version numbers to 6.1.8 in all relevant `package.json` and `package-lock.json` files, and updated the security policy to reflect the new release. (package.json [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) workers/*/package.json [[2]](diffhunk://#diff-d16fb6b09f684160054b5c0e353e35f63f00651bc94bcbcaf521437dfccd9fc9L3-R3) [[3]](diffhunk://#diff-25a913066a7fe613d4b06888c5c4429d3115d670e3a47c1e0093f93ac69b0bc6L3-R3) [[4]](diffhunk://#diff-6b488296f955b235077b13eb5a4be1d4fbec35413644445e150b93f1800aec71L3-R3) [[5]](diffhunk://#diff-0e896c71a77804a30199ade801c401da5f6343c86e21a0e184974feb2a80a941L3-R3) [[6]](diffhunk://#diff-0c2ca2d4f71077b08e99fbcf3b51ff4afd93456ac56a1cfa279ef8ce62e9b445L3-R3) workers/*/package-lock.json [[7]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L3-R9) [[8]](diffhunk://#diff-6e5e36a60c0d36c5b64aa73374f62c57efbd072023660e8d0aec12a4280248c9L3-R9) [[9]](diffhunk://#diff-8aaa33f9d5640156d7cec29c58ba66ec9c932b4c106dc397b9558af952100cebL3-R9) [[10]](diffhunk://#diff-1d4408399474dc9865a67a3928dc47144f925b807fcb91fff6d733905d621e66L3-R9) [[11]](diffhunk://#diff-4f2f3beba65f88db2a2cf66fe5915d9f3fd6d730ef00036a75bf9c3d11c2dc7bL3-R9) .github/SECURITY.md [[12]](diffhunk://#diff-ac3050733d58345444c27d37c6247ef260ad992bcb02782feea43fb580106079L7-R7)