### PR TITLE
bump v7.0.1

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -20,6 +20,12 @@ Striae is a specialized, cloud-native platform designed to streamline forensic f
 
 ## 📋 Changelog
 
+## [2026-04-22] - *[Patch Release v7.0.1](https://github.com/striae-org/striae/releases/tag/v7.0.1)*
+
+- **🖼️ Canvas L/R Notes Display** - Added left/right notes rendering to the canvas component, allowing examiners to view per-side annotation notes directly within the comparison canvas view; updated canvas CSS module and bumped compatibility dates across all worker `wrangler.jsonc.example` files.
+- **⚙️ Worker Response Logic Alignment** - Standardized response handling patterns across the image worker and user worker for consistency; refactored router and handler response construction in the image worker and aligned response/error types and route handling in the user worker.
+- **🧹 Code Review Follow-Up** - Applied minor code review fixes to the user worker including type refinements and removal of stale logic.
+
 ## [2026-04-21] - *[Major Release v7.0.0](https://github.com/striae-org/striae/releases/tag/v7.0.0)*
 
 - **🔗 Service Bindings Migration** - Replaced HTTP-based worker proxying (domain environment variables and URL normalization) with Cloudflare Service Bindings across all five worker proxy functions; removed top-level `worker-configuration.d.ts` and worker domain helper functions from `env-utils.sh`; updated `wrangler.toml.example` and all worker `wrangler.jsonc.example` files.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version     | Supported          |
 | ----------- | ------------------ |
-| v7.0.0  | :white_check_mark: |
+| v7.0.1  | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/.github/release-notes/RELEASE_NOTES_v7.0.1.md
+++ b/.github/release-notes/RELEASE_NOTES_v7.0.1.md
@@ -1,0 +1,42 @@
+# Striae Release Notes - v7.0.1
+
+**Release Date**: April 22, 2026
+**Period**: April 22, 2026 through April 22, 2026
+**Total Commits**: 3 (non-merge after the v7.0.0 bump)
+
+## Patch Release - Canvas Notes and Worker Response Consistency
+
+## Summary
+
+v7.0.1 is a focused patch release following the v7.0.0 service bindings migration. It adds left/right notes display to the canvas annotation view, aligns worker response logic across the image and user workers for consistency, and applies follow-up code review fixes to the user worker.
+
+## Detailed Changes
+
+### Canvas L/R Notes Display
+
+- Added left/right notes rendering to the canvas component, allowing examiners to view per-side annotation notes directly within the comparison canvas view.
+- Updated `canvas.tsx` to surface left and right note values from the canvas props and render them in the overlay.
+- Added supporting styles to `canvas.module.css` for the notes display.
+- Bumped Cloudflare compatibility dates across all worker `wrangler.jsonc.example` files and `wrangler.toml.example`.
+
+### Worker Response Logic Alignment
+
+- Standardized response handling patterns across the image worker and user worker for consistency following the v7.0.0 service bindings migration.
+- Refactored router and handler response construction in the image worker (`delete-image.ts`, `mint-signed-url.ts`, `serve-image.ts`, `upload-image.ts`, `image-worker.ts`, `router.ts`, `types.ts`) to use a consistent response shape.
+- Aligned response and error types and route handling in the user worker (`user-routes.ts`, `user-worker.ts`, `types.ts`).
+
+### Code Review Follow-Up
+
+- Applied minor code review fixes to the user worker including type refinements in `types.ts`, a corrected handler reference in `user-routes.ts`, and removal of stale logic from `user-worker.ts`.
+
+## Release Statistics
+
+- **Baseline**: `.github/release-notes/RELEASE_NOTES_v7.0.0.md`
+- **Commits Included**: 3 (non-merge commits after `v7.0.0` on 04/21/2026)
+- **Build Status**: Passed (`npm run build`)
+- **Typecheck Status**: Passed (`npm run typecheck`)
+- **Lint Status**: Passed (`npm run lint`)
+
+## Closing Note
+
+v7.0.1 completes the first round of follow-up polish after the v7.0.0 infrastructure overhaul. The canvas annotation view now surfaces left/right notes inline, and both the image and user workers have been brought to a consistent response contract. The worker layer is stable and ready for feature development.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@striae-org/striae",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@striae-org/striae",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-router/cloudflare": "^7.14.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@striae-org/striae",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "private": false,
   "description": "Striae is a specialized, cloud-native platform designed to streamline forensic firearms identification by providing an intuitive environment for digital comparison image annotation, authenticated confirmations, and automated report generation.",
   "license": "Apache-2.0",

--- a/workers/audit-worker/package-lock.json
+++ b/workers/audit-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audit-worker",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audit-worker",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "devDependencies": {
         "wrangler": "^4.84.1"
       }

--- a/workers/audit-worker/package.json
+++ b/workers/audit-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-worker",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/data-worker/package-lock.json
+++ b/workers/data-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-worker",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "data-worker",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.14.9",
         "wrangler": "^4.84.1"

--- a/workers/data-worker/package.json
+++ b/workers/data-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-worker",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/image-worker/package-lock.json
+++ b/workers/image-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-worker",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-worker",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "devDependencies": {
         "wrangler": "^4.84.1"
       }

--- a/workers/image-worker/package.json
+++ b/workers/image-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-worker",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/pdf-worker/package-lock.json
+++ b/workers/pdf-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdf-worker",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-worker",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "devDependencies": {
         "wrangler": "^4.84.1"
       }

--- a/workers/pdf-worker/package.json
+++ b/workers/pdf-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-worker",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "private": true,
   "scripts": {
     "generate:assets": "node scripts/generate-assets.js",

--- a/workers/user-worker/package-lock.json
+++ b/workers/user-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "user-worker",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "user-worker",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "devDependencies": {
         "wrangler": "^4.84.1"
       }

--- a/workers/user-worker/package.json
+++ b/workers/user-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-worker",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",


### PR DESCRIPTION
This pull request releases patch version 7.0.1, focusing on UI improvements and backend consistency after the major v7.0.0 update. The most important changes are the addition of left/right notes display in the canvas annotation view, standardization of worker response logic, and minor code review fixes. All relevant package versions have been bumped to 7.0.1.

**Feature and UI Enhancements:**

* Added left/right notes rendering to the canvas component, allowing examiners to view per-side annotation notes directly within the comparison canvas view. Supporting changes include updates to the canvas CSS module and documentation. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R23-R28) [[2]](diffhunk://#diff-21c0c0a374e9e050d551ebfc1b94980b24dcdde863431e34c9219f7099f0e1b5R1-R42)

**Backend and Worker Improvements:**

* Standardized response handling patterns across the image worker and user worker for consistency, including refactoring router and handler response construction and aligning response/error types and route handling. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R23-R28) [[2]](diffhunk://#diff-21c0c0a374e9e050d551ebfc1b94980b24dcdde863431e34c9219f7099f0e1b5R1-R42)

* Applied minor code review fixes to the user worker, such as type refinements and removal of stale logic. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R23-R28) [[2]](diffhunk://#diff-21c0c0a374e9e050d551ebfc1b94980b24dcdde863431e34c9219f7099f0e1b5R1-R42)

**Version and Documentation Updates:**

* Bumped all relevant package versions (`package.json`, all worker `package.json` and `package-lock.json` files) to 7.0.1. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-d16fb6b09f684160054b5c0e353e35f63f00651bc94bcbcaf521437dfccd9fc9L3-R3) [[3]](diffhunk://#diff-25a913066a7fe613d4b06888c5c4429d3115d670e3a47c1e0093f93ac69b0bc6L3-R3) [[4]](diffhunk://#diff-6b488296f955b235077b13eb5a4be1d4fbec35413644445e150b93f1800aec71L3-R3) [[5]](diffhunk://#diff-0e896c71a77804a30199ade801c401da5f6343c86e21a0e184974feb2a80a941L3-R3) [[6]](diffhunk://#diff-0c2ca2d4f71077b08e99fbcf3b51ff4afd93456ac56a1cfa279ef8ce62e9b445L3-R3) [[7]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L3-R9) [[8]](diffhunk://#diff-6e5e36a60c0d36c5b64aa73374f62c57efbd072023660e8d0aec12a4280248c9L3-R9) [[9]](diffhunk://#diff-8aaa33f9d5640156d7cec29c58ba66ec9c932b4c106dc397b9558af952100cebL3-R9) [[10]](diffhunk://#diff-1d4408399474dc9865a67a3928dc47144f925b807fcb91fff6d733905d621e66L3-R9) [[11]](diffhunk://#diff-4f2f3beba65f88db2a2cf66fe5915d9f3fd6d730ef00036a75bf9c3d11c2dc7bL3-R9)

* Updated the security policy and added detailed release notes for v7.0.1. [[1]](diffhunk://#diff-ac3050733d58345444c27d37c6247ef260ad992bcb02782feea43fb580106079L7-R7) [[2]](diffhunk://#diff-21c0c0a374e9e050d551ebfc1b94980b24dcdde863431e34c9219f7099f0e1b5R1-R42)