### PR TITLE
bump v7.1.0

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -20,6 +20,14 @@ Striae is a specialized, cloud-native platform designed to streamline forensic f
 
 ## 📋 Changelog
 
+## [2026-04-25] - *[Minor Release v7.1.0](https://github.com/striae-org/striae/releases/tag/v7.1.0)*
+
+- **📋 Lists Worker** - Added a dedicated Cloudflare Worker (`lists-worker`) for KV-backed email allowlist management; exposes auth-gated GET/POST/DELETE endpoints for member and Primer Shear lists with constant-time auth comparison; integrated into the Pages registration flow via a service binding and shared client helper.
+- **🔗 Registration Allowlist Integration** - Refactored registration allowlist and check paths to use the lists-worker service binding instead of static config files; removed `members.emails` and `primershear.emails` config-example files superseded by KV storage.
+- **🧹 Dead Script Cleanup** - Removed `deploy-members-emails.sh`, `deploy-primershear-emails.sh`, and related package script references; updated deploy-config scaffolding to register the new lists worker.
+- **🔐 UUID Security Fix** - Resolved a known `uuid` package vulnerability via a scoped npm override targeting the `firebase-admin` dependency chain.
+- **⚙️ Maintenance** - Bumped Vite, applied general dependency updates, and refreshed Cloudflare compatibility dates across the app and workers.
+
 ## [2026-04-22] - *[Patch Release v7.0.1](https://github.com/striae-org/striae/releases/tag/v7.0.1)*
 
 - **🖼️ Canvas L/R Notes Display** - Added left/right notes rendering to the canvas component, allowing examiners to view per-side annotation notes directly within the comparison canvas view; updated canvas CSS module and bumped compatibility dates across all worker `wrangler.jsonc.example` files.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version     | Supported          |
 | ----------- | ------------------ |
-| v7.0.1  | :white_check_mark: |
+| v7.1.0  | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/.github/release-notes/RELEASE_NOTES_v7.1.0.md
+++ b/.github/release-notes/RELEASE_NOTES_v7.1.0.md
@@ -1,0 +1,59 @@
+# Striae Release Notes - v7.1.0
+
+**Release Date**: April 25, 2026
+**Period**: April 23, 2026 through April 25, 2026
+**Total Commits**: 17 (non-merge after the v7.0.1 bump)
+
+## Minor Release - Lists Worker and Registration Allowlist Overhaul
+
+## Summary
+
+v7.1.0 introduces a dedicated Cloudflare Worker (`lists-worker`) to replace static config-file-based email list management for member and Primer Shear registration allowlists. The lists worker exposes a KV-backed, auth-gated API for reading and managing email entries, and is integrated into the Pages registration flow via a service binding and a shared client helper. This release also resolves a UUID package vulnerability, cleans up dead email deployment scripts and Durable Object scaffolding, and applies post-integration registration check fixes.
+
+## Detailed Changes
+
+### Lists Worker
+
+- Added a new `workers/lists-worker/` Cloudflare Worker that serves as the authoritative backend for email allowlist management.
+- The worker stores and retrieves comma-delimited email lists from a KV namespace (`STRIAE_LISTS`), keyed by list type (`allow` for members, `primershear` for Primer Shear).
+- Supports `GET` (read full list), `POST` (add entry), and `DELETE` (remove entry) operations, all gated by a `LISTS_ADMIN_SECRET` Bearer token with constant-time comparison to mitigate timing side-channels.
+- Added `workers/lists-worker/wrangler.jsonc.example` and `workers/lists-worker/package.json` for worker scaffolding.
+- Removed an early Durable Objects-based variant (`lists-do.ts`) in favor of a simpler KV-only implementation.
+
+### Registration Allowlist Integration
+
+- Added `functions/api/_shared/lists-client.ts` — a shared client helper that reads email lists from the lists-worker via service binding, returning a typed `ListResult` (ok/error) to allow callers to apply fail-open or fail-closed logic appropriate to their security context.
+- Refactored `functions/api/_shared/registration-allowlist.ts` to use the lists-client instead of static config file reads.
+- Updated `functions/api/user/[[path]].ts` to integrate the new lists-worker service binding into the registration check path.
+- Fixed registration allowlist logic and a registration check path bug introduced during the integration.
+- Removed static `app/config-example/members.emails` and `app/config-example/primershear.emails` config-example files, superseded by KV-backed storage.
+
+### Dead Script and Config Cleanup
+
+- Removed `scripts/deploy-members-emails.sh` and `scripts/deploy-primershear-emails.sh` — email list deployment scripts that are no longer needed with the lists-worker KV approach.
+- Removed related script references from `package.json` and updated `scripts/deploy-all.sh` and `scripts/deploy-worker-secrets.sh` accordingly.
+- Updated `scripts/deploy-config/` modules (`prompt.sh`, `scaffolding.sh`, `validation.sh`) to support lists-worker registration during deploy config setup.
+
+### Security Fix - UUID Vulnerability
+
+- Applied an npm override to resolve a known vulnerability in the `uuid` package pulled in by `firebase-admin`.
+- Scoped the override precisely to the `firebase-admin` dependency chain to avoid unintended side effects elsewhere.
+
+### Maintenance
+
+- Bumped Vite across the app.
+- Applied general dependency bumps and Cloudflare compatibility date refreshes across the app and workers.
+- Updated `.gitignore` for the lists worker artifact directory.
+- Applied deploy refresh and miscellaneous code review follow-ups.
+
+## Release Statistics
+
+- **Baseline**: `.github/release-notes/RELEASE_NOTES_v7.0.1.md`
+- **Commits Included**: 17 (non-merge commits after `v7.0.1` on 04/22/2026)
+- **Build Status**: Passed (`npm run build`)
+- **Typecheck Status**: Passed (`npm run typecheck`)
+- **Lint Status**: Passed (`npm run lint`)
+
+## Closing Note
+
+v7.1.0 completes the migration of email allowlist management from static config files to a dedicated, KV-backed lists worker. The registration flow is now fully dynamic and operator-managed without requiring a redeploy to update lists. The UUID security fix and general maintenance polish round out the release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@striae-org/striae",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@striae-org/striae",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-router/cloudflare": "^7.14.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@striae-org/striae",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "private": false,
   "description": "Striae is a specialized, cloud-native platform designed to streamline forensic firearms identification by providing an intuitive environment for digital comparison image annotation, authenticated confirmations, and automated report generation.",
   "license": "Apache-2.0",

--- a/workers/audit-worker/package-lock.json
+++ b/workers/audit-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audit-worker",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audit-worker",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "devDependencies": {
         "wrangler": "^4.85.0"
       }

--- a/workers/audit-worker/package.json
+++ b/workers/audit-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-worker",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/data-worker/package-lock.json
+++ b/workers/data-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-worker",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "data-worker",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.14.9",
         "wrangler": "^4.85.0"

--- a/workers/data-worker/package.json
+++ b/workers/data-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-worker",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/image-worker/package-lock.json
+++ b/workers/image-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-worker",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-worker",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "devDependencies": {
         "wrangler": "^4.85.0"
       }

--- a/workers/image-worker/package.json
+++ b/workers/image-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-worker",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/lists-worker/package-lock.json
+++ b/workers/lists-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lists-worker",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lists-worker",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "devDependencies": {
         "wrangler": "^4.85.0"
       }

--- a/workers/lists-worker/package.json
+++ b/workers/lists-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lists-worker",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/pdf-worker/package-lock.json
+++ b/workers/pdf-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdf-worker",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-worker",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "devDependencies": {
         "wrangler": "^4.85.0"
       }

--- a/workers/pdf-worker/package.json
+++ b/workers/pdf-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-worker",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "private": true,
   "scripts": {
     "generate:assets": "node scripts/generate-assets.js",

--- a/workers/user-worker/package-lock.json
+++ b/workers/user-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "user-worker",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "user-worker",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "devDependencies": {
         "wrangler": "^4.85.0"
       }

--- a/workers/user-worker/package.json
+++ b/workers/user-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-worker",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",


### PR DESCRIPTION
This pull request releases Striae v7.1.0, a minor release focused on overhauling email allowlist management for registration by introducing a dedicated Cloudflare Worker, improving security, and performing general maintenance and cleanup. The main highlight is the migration from static config files to a KV-backed, operator-managed lists worker, making allowlist updates dynamic and more secure. Additional changes include dependency bumps, a UUID vulnerability fix, and removal of obsolete scripts.

**Major features and improvements:**

*Email Allowlist Overhaul*
- Introduced a new Cloudflare Worker (`lists-worker`) for managing member and Primer Shear email allowlists, replacing static config files with a KV-backed, API-driven solution. The worker exposes secure, auth-gated endpoints for list management and is integrated into the registration flow via a service binding and shared client helper. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R23-R30) [[2]](diffhunk://#diff-f6ef921d62375ac515ebd2cd0b56b2a5c37b6c48c7b56db9c39ba83ffad74652R1-R59)

*Integration and Refactoring*
- Refactored registration allowlist logic and registration check paths to use the new lists-worker, removed config-example email files, and updated related modules and deployment scaffolding accordingly.

*Security*
- Resolved a known vulnerability in the `uuid` package (used by `firebase-admin`) by applying a scoped npm override. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R23-R30) [[2]](diffhunk://#diff-f6ef921d62375ac515ebd2cd0b56b2a5c37b6c48c7b56db9c39ba83ffad74652R1-R59)

*Cleanup*
- Removed obsolete email deployment scripts and related references from `package.json` and deployment scripts, and cleaned up Durable Object scaffolding. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R23-R30) [[2]](diffhunk://#diff-f6ef921d62375ac515ebd2cd0b56b2a5c37b6c48c7b56db9c39ba83ffad74652R1-R59)

*Maintenance*
- Bumped Vite and other dependencies, refreshed Cloudflare compatibility dates, and updated version numbers across all workers and packages. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L3-R9) [[3]](diffhunk://#diff-d16fb6b09f684160054b5c0e353e35f63f00651bc94bcbcaf521437dfccd9fc9L3-R3) [[4]](diffhunk://#diff-6e5e36a60c0d36c5b64aa73374f62c57efbd072023660e8d0aec12a4280248c9L3-R9) [[5]](diffhunk://#diff-25a913066a7fe613d4b06888c5c4429d3115d670e3a47c1e0093f93ac69b0bc6L3-R3) [[6]](diffhunk://#diff-8aaa33f9d5640156d7cec29c58ba66ec9c932b4c106dc397b9558af952100cebL3-R9) [[7]](diffhunk://#diff-6b488296f955b235077b13eb5a4be1d4fbec35413644445e150b93f1800aec71L3-R3) [[8]](diffhunk://#diff-237cd9065b0326cd283962fedd9d0c680814dedcbf11f08de91d6ebe061c05d0L3-R9) [[9]](diffhunk://#diff-b4e4eeabc3f819e9d58d3f53bef732bdda3c7b4e920ce7efa299a59a6720f13bL3-R3) [[10]](diffhunk://#diff-1d4408399474dc9865a67a3928dc47144f925b807fcb91fff6d733905d621e66L3-R9) [[11]](diffhunk://#diff-0e896c71a77804a30199ade801c401da5f6343c86e21a0e184974feb2a80a941L3-R3) [[12]](diffhunk://#diff-4f2f3beba65f88db2a2cf66fe5915d9f3fd6d730ef00036a75bf9c3d11c2dc7bL3-R9) [[13]](diffhunk://#diff-0c2ca2d4f71077b08e99fbcf3b51ff4afd93456ac56a1cfa279ef8ce62e9b445L3-R3) [[14]](diffhunk://#diff-ac3050733d58345444c27d37c6247ef260ad992bcb02782feea43fb580106079L7-R7)

For further details, see the full release notes in `.github/release-notes/RELEASE_NOTES_v7.1.0.md`.