### PR TITLE
bump v10.0.0

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -20,6 +20,14 @@ Striae is a specialized, cloud-native platform designed to streamline forensic f
 
 ## 📋 Changelog
 
+## [2026-08-11] - *[Major Release v10.0.0](https://github.com/striae-org/striae/releases/tag/v10.0.0)* — *Files Worker + Non-Image File Management*
+
+- **🗂️ Files Worker and Storage Architecture** - Added a dedicated `files-worker` and integrated it into deployment scaffolding, environment validation, and worker configuration so associated non-image files have a dedicated storage layer.
+- **📁 Non-Image File Management Flow** - Implemented the end-to-end associated-file workflow in the app, including upload, listing, deletion, progress indication, and navbar/file modal integration for case-scoped non-image file operations.
+- **🔐 Manifest, Export, and Import Integrity** - Updated archive/export packaging and manifest/decryption validation to carry associated non-image files through case exports and import verification without breaking integrity checks.
+- **🧹 File Lifecycle Follow-Ups** - Fixed upload path resolution, navbar state behavior, styling issues, and case-deletion handling so the new file-management flow is consistent and stable.
+- **🧰 Release Metadata Refresh** - Updated package metadata and release documentation to reflect the v10.0.0 major release line.
+
 ## [2026-08-11] - *[Patch Release v9.1.1](https://github.com/striae-org/striae/releases/tag/v9.1.1)* — *Script-Based Publish Flow Restoration + Dependency/Compatibility Maintenance + Lists Worker Endpoint Stabilization*
 
 - **📦 Script-Based Publish Flow Restoration** - Restored the pre-v9.1.1 npm script publish flow for npmjs and GitHub Packages using the package-level `publish:npm`, `publish:github`, and `publish:all` commands instead of the tag-triggered GitHub Actions release workflow.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported |
 | ------- | --------- |
-| v9.1.1 | :white_check_mark: |
+| v10.0.0 | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/.github/release-notes/RELEASE_NOTES_v10.0.0.md
+++ b/.github/release-notes/RELEASE_NOTES_v10.0.0.md
@@ -1,0 +1,56 @@
+# Striae Release Notes - v10.0.0
+
+**Release Date**: August 11, 2026
+**Period**: August 11, 2026
+**Total Commits**: 15 (non-merge after the v9.1.1 release)
+
+## Major Release - Files Worker + Non-Image File Management
+
+## Summary
+
+v10.0.0 introduces the dedicated files worker and completes the end-to-end non-image file management flow for Striae cases. The release adds a first-class storage worker for associated case files, wires upload/download/delete handling through the app and worker boundaries, and integrates file lifecycle checks into export, import, archive, and case-deletion flows.
+
+## Detailed Changes
+
+### Files Worker and Storage Architecture
+
+- Added a dedicated `files-worker` with worker-scoped scaffolding, environment configuration, and deployment setup for case-associated non-image file storage.
+- Integrated the new files worker into the shared worker deployment and config scaffolding paths so the new storage layer is consistent with the rest of the platform.
+- Corrected environment validation and configuration replacement issues so files-worker setup and runtime checks remain stable across deploy and dev flows.
+
+### Non-Image File Management End-to-End Flow
+
+- Added the main non-image file management experience in the app, including upload, listing, deletion, and associated-file management UI along the image/file management area.
+- Implemented drag-and-drop upload behavior, progress indication, and ready-state styling to improve the file-management experience during case operations.
+- Fixed file upload path resolution and active-state navbar behavior so associated-file actions stay aligned with the current case context.
+- Added the backend flow for managing case files across app and worker boundaries, including the dedicated storage and retrieval path for associated non-image files.
+
+### Manifest, Archive, Export, and Import Integrity
+
+- Updated export and archive packaging to include associated non-image files in the case bundle and encrypted file manifest flow.
+- Tightened manifest, decryption, and verification checks so exported and imported associated files remain traceable and valid during package handling.
+- Adjusted archive/export progress indicators and file-size handling to reflect the new file-management workflow and support larger associated files.
+- Ensured case deletion and import paths properly account for associated non-image files so they are removed or verified as part of the lifecycle rather than being left behind.
+
+### Security and Release Hardening
+
+- Hardened the file-management path with validation and safety checks around manifest/decrypt flows, upload handling, and archive packaging.
+- Applied CSS/button polish and label alignment follow-ups to keep the new file-management flow visually consistent with the rest of the app.
+- Set the per-file upload limit to 512 MB for the non-image file workflow to match the supported associated-file bundle design.
+
+### Release Metadata Alignment
+
+- Updated package and worker metadata to v10.0.0.
+- Refreshed supported-version metadata and release documentation for the new major release line.
+
+## Release Statistics
+
+- **Baseline**: .github/release-notes/RELEASE_NOTES_v9.1.1.md
+- **Commits Included**: 15 (non-merge commits from 2026-08-11 through 2026-08-11)
+- **Build Status**: Passed (`npm run build`)
+- **Typecheck Status**: Passed (`npm run typecheck`)
+- **Lint Status**: Passed (`npm run lint`)
+
+## Closing Note
+
+v10.0.0 completes the migration to a dedicated files worker and delivers the new associated-file management lifecycle for Striae cases. The release brings upload, export, manifest integrity, import verification, and deletion handling under one consistent non-image file flow while keeping the app and worker deployment surfaces aligned.

--- a/app/utils/api/files-api-client.ts
+++ b/app/utils/api/files-api-client.ts
@@ -48,8 +48,60 @@ interface XhrUploadResult {
   responseText: string;
 }
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isUploadErrorsArray(
+  value: unknown
+): value is Array<{ code: number; message: string }> {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        'code' in entry &&
+        typeof entry.code === 'number' &&
+        'message' in entry &&
+        typeof entry.message === 'string'
+    )
+  );
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}
+
 function isUploadSuccessResponse(value: unknown): value is FileUploadResponse {
-  return !!value && typeof value === 'object' && 'success' in value && value.success === true && 'result' in value && !!value.result && typeof value.result === 'object' && 'id' in value.result && !!value.result.id;
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as {
+    success?: unknown;
+    result?: unknown;
+    errors?: unknown;
+    messages?: unknown;
+  };
+
+  if (candidate.success !== true || !candidate.result || typeof candidate.result !== 'object') {
+    return false;
+  }
+
+  const result = candidate.result as {
+    id?: unknown;
+    filename?: unknown;
+    uploaded?: unknown;
+  };
+
+  return (
+    isNonEmptyString(result.id) &&
+    isNonEmptyString(result.filename) &&
+    isNonEmptyString(result.uploaded) &&
+    isUploadErrorsArray(candidate.errors) &&
+    isStringArray(candidate.messages)
+  );
 }
 
 function uploadWithXhr(

--- a/app/utils/api/files-api-client.ts
+++ b/app/utils/api/files-api-client.ts
@@ -48,8 +48,8 @@ interface XhrUploadResult {
   responseText: string;
 }
 
-interface UploadErrorResponse {
-  error: string;
+function isUploadSuccessResponse(value: unknown): value is FileUploadResponse {
+  return !!value && typeof value === 'object' && 'success' in value && value.success === true && 'result' in value && !!value.result && typeof value.result === 'object' && 'id' in value.result && !!value.result.id;
 }
 
 function uploadWithXhr(
@@ -88,14 +88,19 @@ function uploadWithXhr(
 }
 
 function parseUploadResponse(payload: string): FileUploadResponse {
-  const parsed = JSON.parse(payload) as FileUploadResponse | UploadErrorResponse;
+  const parsed = JSON.parse(payload) as unknown;
 
-  if ('error' in parsed && typeof parsed.error === 'string' && parsed.error.trim()) {
+  if (parsed && typeof parsed === 'object' && 'error' in parsed && typeof parsed.error === 'string' && parsed.error.trim()) {
     throw new Error(parsed.error);
   }
 
-  if (!parsed.success || !parsed.result?.id) {
-    const errorMessage = parsed.errors?.map((entry) => entry.message).join(', ') || 'Upload failed';
+  if (!isUploadSuccessResponse(parsed)) {
+    const errorMessage =
+      parsed && typeof parsed === 'object' && 'errors' in parsed && Array.isArray(parsed.errors)
+        ? parsed.errors
+            .map((entry) => (typeof entry === 'object' && entry && 'message' in entry && typeof entry.message === 'string' ? entry.message : 'Upload failed'))
+            .join(', ')
+        : 'Upload failed';
     throw new Error(errorMessage);
   }
 

--- a/app/utils/api/image-api-client.ts
+++ b/app/utils/api/image-api-client.ts
@@ -48,8 +48,8 @@ interface XhrUploadResult {
   responseText: string;
 }
 
-interface UploadErrorResponse {
-  error: string;
+function isUploadSuccessResponse(value: unknown): value is ImageUploadResponse {
+  return !!value && typeof value === 'object' && 'success' in value && value.success === true && 'result' in value && !!value.result && typeof value.result === 'object' && 'id' in value.result && !!value.result.id;
 }
 
 function uploadWithXhr(
@@ -88,14 +88,19 @@ function uploadWithXhr(
 }
 
 function parseUploadResponse(payload: string): ImageUploadResponse {
-  const parsed = JSON.parse(payload) as ImageUploadResponse | UploadErrorResponse;
+  const parsed = JSON.parse(payload) as unknown;
 
-  if ('error' in parsed && typeof parsed.error === 'string' && parsed.error.trim()) {
+  if (parsed && typeof parsed === 'object' && 'error' in parsed && typeof parsed.error === 'string' && parsed.error.trim()) {
     throw new Error(parsed.error);
   }
 
-  if (!parsed.success || !parsed.result?.id) {
-    const errorMessage = parsed.errors?.map((entry) => entry.message).join(', ') || 'Upload failed';
+  if (!isUploadSuccessResponse(parsed)) {
+    const errorMessage =
+      parsed && typeof parsed === 'object' && 'errors' in parsed && Array.isArray(parsed.errors)
+        ? parsed.errors
+            .map((entry) => (typeof entry === 'object' && entry && 'message' in entry && typeof entry.message === 'string' ? entry.message : 'Upload failed'))
+            .join(', ')
+        : 'Upload failed';
     throw new Error(errorMessage);
   }
 

--- a/app/utils/api/image-api-client.ts
+++ b/app/utils/api/image-api-client.ts
@@ -48,8 +48,60 @@ interface XhrUploadResult {
   responseText: string;
 }
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isUploadErrorsArray(
+  value: unknown
+): value is Array<{ code: number; message: string }> {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        'code' in entry &&
+        typeof entry.code === 'number' &&
+        'message' in entry &&
+        typeof entry.message === 'string'
+    )
+  );
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}
+
 function isUploadSuccessResponse(value: unknown): value is ImageUploadResponse {
-  return !!value && typeof value === 'object' && 'success' in value && value.success === true && 'result' in value && !!value.result && typeof value.result === 'object' && 'id' in value.result && !!value.result.id;
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as {
+    success?: unknown;
+    result?: unknown;
+    errors?: unknown;
+    messages?: unknown;
+  };
+
+  if (candidate.success !== true || !candidate.result || typeof candidate.result !== 'object') {
+    return false;
+  }
+
+  const result = candidate.result as {
+    id?: unknown;
+    filename?: unknown;
+    uploaded?: unknown;
+  };
+
+  return (
+    isNonEmptyString(result.id) &&
+    isNonEmptyString(result.filename) &&
+    isNonEmptyString(result.uploaded) &&
+    isUploadErrorsArray(candidate.errors) &&
+    isStringArray(candidate.messages)
+  );
 }
 
 function uploadWithXhr(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@striae-org/striae",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@striae-org/striae",
-      "version": "9.1.1",
+      "version": "10.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-router/cloudflare": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@striae-org/striae",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "private": false,
   "description": "Striae is a specialized, cloud-native platform designed to streamline forensic firearms identification by providing an intuitive environment for digital comparison image annotation, authenticated confirmations, and automated report generation.",
   "license": "Apache-2.0",

--- a/workers/audit-worker/package-lock.json
+++ b/workers/audit-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audit-worker",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audit-worker",
-      "version": "9.1.1",
+      "version": "10.0.0",
       "devDependencies": {
         "wrangler": "^4.121.0"
       }

--- a/workers/audit-worker/package.json
+++ b/workers/audit-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-worker",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/data-worker/package-lock.json
+++ b/workers/data-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-worker",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "data-worker",
-      "version": "9.1.1",
+      "version": "10.0.0",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.20.3",
         "wrangler": "^4.121.0"

--- a/workers/data-worker/package.json
+++ b/workers/data-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-worker",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/image-worker/package-lock.json
+++ b/workers/image-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-worker",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-worker",
-      "version": "9.1.1",
+      "version": "10.0.0",
       "devDependencies": {
         "wrangler": "^4.121.0"
       }

--- a/workers/image-worker/package.json
+++ b/workers/image-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-worker",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/lists-worker/package-lock.json
+++ b/workers/lists-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lists-worker",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lists-worker",
-      "version": "9.1.1",
+      "version": "10.0.0",
       "devDependencies": {
         "wrangler": "^4.121.0"
       }

--- a/workers/lists-worker/package.json
+++ b/workers/lists-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lists-worker",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/pdf-worker/package-lock.json
+++ b/workers/pdf-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdf-worker",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-worker",
-      "version": "9.1.1",
+      "version": "10.0.0",
       "devDependencies": {
         "wrangler": "^4.121.0"
       }

--- a/workers/pdf-worker/package.json
+++ b/workers/pdf-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-worker",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "private": true,
   "scripts": {
     "generate:assets": "node scripts/generate-assets.js",

--- a/workers/user-worker/package-lock.json
+++ b/workers/user-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "user-worker",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "user-worker",
-      "version": "9.1.1",
+      "version": "10.0.0",
       "devDependencies": {
         "wrangler": "^4.121.0"
       }

--- a/workers/user-worker/package.json
+++ b/workers/user-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-worker",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",


### PR DESCRIPTION
This pull request delivers the v10.0.0 major release for Striae, introducing a dedicated files worker and a complete non-image file management workflow for case-associated files. It also includes improvements to file upload validation, manifest integrity, and overall release metadata alignment. The update touches both backend and frontend, ensuring the new file management flow is robust, secure, and integrated across the app and worker boundaries.

**Major Features and Architecture:**

* Added a dedicated `files-worker` with deployment scaffolding, environment validation, and integration into the platform for robust non-image file storage and management. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R23-R30) [[2]](diffhunk://#diff-271f0510531f7aeb403611533f81b43423ecd32425b4864027ec3536c7b997a6R1-R56)
* Implemented a complete non-image file management flow, including upload, listing, deletion, progress indication, and UI integration for case-scoped files. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R23-R30) [[2]](diffhunk://#diff-271f0510531f7aeb403611533f81b43423ecd32425b4864027ec3536c7b997a6R1-R56)

**Data Integrity and Security:**

* Enhanced manifest, export, and import handling to ensure associated non-image files are properly included and validated during case archiving and transfer, maintaining integrity checks. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R23-R30) [[2]](diffhunk://#diff-271f0510531f7aeb403611533f81b43423ecd32425b4864027ec3536c7b997a6R1-R56)
* Hardened file-management paths with improved validation, safety checks, and a per-file upload limit of 512 MB for non-image files.

**Frontend/Backend Improvements:**

* Refactored upload response validation in both `image-api-client.ts` and `files-api-client.ts` to robustly check for success and error conditions, improving error handling and reliability. [[1]](diffhunk://#diff-a39ba2506ecd6743d50216dec882564369eee565850a76d161df59bfd963bc12L51-R52) [[2]](diffhunk://#diff-a39ba2506ecd6743d50216dec882564369eee565850a76d161df59bfd963bc12L91-R103) [[3]](diffhunk://#diff-3e5c8415733f55ee6f5a90fda780eede4ce41b48e3a9329e8c50275cd0886419L51-R52) [[4]](diffhunk://#diff-3e5c8415733f55ee6f5a90fda780eede4ce41b48e3a9329e8c50275cd0886419L91-R103)

**Release and Metadata Updates:**

* Updated all package versions and metadata to `v10.0.0`, including `package.json`, worker packages, and release documentation, and marked v10.0.0 as the supported version in `SECURITY.md`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L3-R9) [[3]](diffhunk://#diff-d16fb6b09f684160054b5c0e353e35f63f00651bc94bcbcaf521437dfccd9fc9L3-R3) [[4]](diffhunk://#diff-6e5e36a60c0d36c5b64aa73374f62c57efbd072023660e8d0aec12a4280248c9L3-R9) [[5]](diffhunk://#diff-25a913066a7fe613d4b06888c5c4429d3115d670e3a47c1e0093f93ac69b0bc6L3-R3) [[6]](diffhunk://#diff-8aaa33f9d5640156d7cec29c58ba66ec9c932b4c106dc397b9558af952100cebL3-R9) [[7]](diffhunk://#diff-6b488296f955b235077b13eb5a4be1d4fbec35413644445e150b93f1800aec71L3-R3) [[8]](diffhunk://#diff-237cd9065b0326cd283962fedd9d0c680814dedcbf11f08de91d6ebe061c05d0L3-R9) [[9]](diffhunk://#diff-b4e4eeabc3f819e9d58d3f53bef732bdda3c7b4e920ce7efa299a59a6720f13bL3-R3) [[10]](diffhunk://#diff-1d4408399474dc9865a67a3928dc47144f925b807fcb91fff6d733905d621e66L3-R9) [[11]](diffhunk://#diff-0e896c71a77804a30199ade801c401da5f6343c86e21a0e184974feb2a80a941L3-R3) [[12]](diffhunk://#diff-4f2f3beba65f88db2a2cf66fe5915d9f3fd6d730ef00036a75bf9c3d11c2dc7bL3-R9) [[13]](diffhunk://#diff-0c2ca2d4f71077b08e99fbcf3b51ff4afd93456ac56a1cfa279ef8ce62e9b445L3-R3) [[14]](diffhunk://#diff-ac3050733d58345444c27d37c6247ef260ad992bcb02782feea43fb580106079L7-R7) [[15]](diffhunk://#diff-271f0510531f7aeb403611533f81b43423ecd32425b4864027ec3536c7b997a6R1-R56)