### PR TITLE
fix files worker version updates

### DIFF
--- a/scripts/update-markdown-versions.cjs
+++ b/scripts/update-markdown-versions.cjs
@@ -10,6 +10,7 @@ const markdownFiles = [
 const workerDirs = [
   'workers/audit-worker',
   'workers/data-worker',
+  'workers/files-worker',
   'workers/image-worker',
   'workers/lists-worker',
   'workers/pdf-worker',

--- a/workers/files-worker/package-lock.json
+++ b/workers/files-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "files-worker",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "files-worker",
-      "version": "9.1.1",
+      "version": "10.0.0",
       "devDependencies": {
         "wrangler": "^4.121.0"
       }

--- a/workers/files-worker/package.json
+++ b/workers/files-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "files-worker",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",


### PR DESCRIPTION
This pull request updates the `files-worker` package to version 10.0.0 and ensures it is included in the list of worker directories for markdown version updates. The main changes are version bumps and configuration updates.

Version updates:

* Bumped the version of `files-worker` to `10.0.0` in both `package.json` and `package-lock.json` to reflect the new release. [[1]](diffhunk://#diff-817a8feb4248f5365f365346c5b6db440c0421d1e566446da782d17d3d39d3edL3-R3) [[2]](diffhunk://#diff-2e570683d145e3fa7b1063ce1d683872c51eecd3ea3a8fe5dd3d440205c04471L3-R9)

Build and configuration:

* Added `workers/files-worker` to the `workerDirs` array in `scripts/update-markdown-versions.cjs`, ensuring it is included in markdown version update scripts.