### PR TITLE
fix worker env var deployments

### DIFF
--- a/scripts/deploy-worker-secrets.sh
+++ b/scripts/deploy-worker-secrets.sh
@@ -159,6 +159,20 @@ build_audit_worker_secret_list() {
     printf '%s\n' "${secrets[@]}"
 }
 
+clear_plaintext_var_bindings() {
+    local worker_name="$1"
+    local config_worker_name="$2"
+
+    echo -e "${YELLOW}  Detected conflicting plaintext var bindings for $worker_name. Clearing remote vars and retrying...${NC}"
+
+    if ! wrangler deploy --name "$config_worker_name" --keep-vars=false; then
+        echo -e "${RED}❌ Failed to clear plaintext vars for $worker_name${NC}"
+        return 1
+    fi
+
+    echo -e "${GREEN}✅ Cleared plaintext vars for $worker_name${NC}"
+}
+
 # Function to set worker secrets
 set_worker_secrets() {
     local worker_name=$1
@@ -193,10 +207,31 @@ set_worker_secrets() {
     fi
     
     echo -e "${YELLOW}  Using worker name: $config_worker_name${NC}"
+    local did_clear_plaintext_vars=0
     
     for secret in "${secrets[@]}"; do
         echo -e "${YELLOW}  Setting $secret...${NC}"
-        if ! echo "${!secret}" | wrangler secret put "$secret" --name "$config_worker_name"; then
+        local set_output
+        if ! set_output=$(printf '%s' "${!secret}" | wrangler secret put "$secret" --name "$config_worker_name" 2>&1); then
+            if [ $did_clear_plaintext_vars -eq 0 ] && echo "$set_output" | grep -qi "already in use"; then
+                if ! clear_plaintext_var_bindings "$worker_name" "$config_worker_name"; then
+                    popd > /dev/null
+                    return 1
+                fi
+
+                did_clear_plaintext_vars=1
+
+                if ! set_output=$(printf '%s' "${!secret}" | wrangler secret put "$secret" --name "$config_worker_name" 2>&1); then
+                    echo "$set_output"
+                    echo -e "${RED}❌ Failed to set $secret for $worker_name after clearing plaintext vars${NC}"
+                    popd > /dev/null
+                    return 1
+                fi
+
+                continue
+            fi
+
+            echo "$set_output"
             echo -e "${RED}❌ Failed to set $secret for $worker_name${NC}"
             popd > /dev/null
             return 1

--- a/workers/files-worker/wrangler.jsonc.example
+++ b/workers/files-worker/wrangler.jsonc.example
@@ -12,13 +12,6 @@
 	"enabled": true
   },
 
-  "vars": {
-    "FILES_UPLOAD_RATE_LIMIT_PER_MINUTE": "30",
-    "FILES_SIGNED_URL_RATE_LIMIT_PER_MINUTE": "120",
-    "FILES_DELETE_RATE_LIMIT_PER_MINUTE": "30",
-    "FILES_MALWARE_SCAN_HOOK_TIMEOUT_MS": "2500"
-  },
-
   "r2_buckets": [
     {
       "binding": "STRIAE_FILES",


### PR DESCRIPTION
This pull request improves the deployment script for worker secrets by adding logic to automatically handle conflicts with existing plaintext variable bindings. It introduces a helper function to clear conflicting variables and retries the secret setting process, making deployments more robust and less prone to manual intervention. Additionally, it removes example plaintext variable bindings from the `wrangler.jsonc.example` file.

Secret deployment robustness improvements:

* Added a `clear_plaintext_var_bindings` function to `scripts/deploy-worker-secrets.sh` that clears conflicting plaintext variable bindings and retries secret deployment when a conflict is detected.
* Updated the `set_worker_secrets` function to detect "already in use" errors, invoke the clearing function, and retry setting the secret, improving automation and error handling during secret deployment.

Configuration cleanup:

* Removed plaintext variable bindings from `workers/files-worker/wrangler.jsonc.example` to encourage the use of secrets for sensitive or environment-specific configuration.