### PR TITLE
add CLA and other legal notice updates

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -1,0 +1,48 @@
+# Striae Individual Contributor License Agreement
+
+Thank you for your interest in contributing to Striae ("We" or "Us").
+
+This contributor agreement ("Agreement") documents the rights granted by contributors to Us. To make this document effective, please sign it by submitting a pull request to a Striae repository and posting the sign-off comment requested by the CLA Assistant bot. This is a legally binding document, so please read it carefully before agreeing to it. This Agreement covers the `striae-org/striae` repository and any other repository owned by Striae that references this Agreement.
+
+## 1. Definitions
+
+**"You"** means the individual who submits a Contribution to Us.
+
+**"Contribution"** means any work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to Us for inclusion in, or documentation of, any of the products owned or managed by Us (the "Work"). For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to Us or our representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Us for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us and to recipients of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us and to recipients of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted. If any entity institutes patent litigation against You or any other entity (including a cross-claim or counterclaim in a lawsuit) alleging that your Contribution, or the Work to which you have contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution or Work shall terminate as of the date such litigation is filed.
+
+## 4. You Retain Ownership
+
+You retain all right, title, and interest in and to Your Contributions. The rights that You grant to Us under this Agreement are effective on the date You first submitted a Contribution to Us, even if Your submission took place before the date You sign this Agreement.
+
+## 5. Representations
+
+You represent that You are legally entitled to grant the above license. If Your employer has rights to intellectual property that You create that includes Your Contributions, You represent that You have received permission to make Contributions on behalf of that employer, or that Your employer has waived such rights for Your Contributions to Us.
+
+You represent that each of Your Contributions is Your original creation. You represent that Your Contribution submissions include complete details of any third-party license or other restriction (including, but not limited to, related patents and trademarks) of which You are personally aware and which are associated with any part of Your Contributions.
+
+## 6. No Warranty
+
+You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all. Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Notification of Inaccuracies
+
+You agree to notify Us of any facts or circumstances of which You become aware that would make these representations inaccurate in any respect.
+
+## How to Sign
+
+Signing this Agreement is handled entirely within your pull request:
+
+1. Open a pull request against a Striae repository covered by this Agreement.
+2. If you have not signed before, the CLA Assistant bot will comment on your pull request with instructions.
+3. Reply to that comment with the exact sign-off text requested by the bot.
+4. Your signature is recorded automatically and applies to all future Contributions covered by this Agreement.
+
+Questions about this Agreement can be directed to [dev@striae.org](mailto:dev@striae.org).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,7 @@
 # Contributing to Striae
 
 Want to contribute to Striae? Please contact us at [dev@striae.org](mailto:dev@striae.org).
+
+## Contributor License Agreement
+
+All contributions to Striae require signing the [Individual Contributor License Agreement](CLA.md). When you open your first pull request, the CLA Assistant bot will comment with sign-off instructions; simply reply with the requested text on your pull request to sign. Your signature is recorded automatically and covers all future contributions.

--- a/.github/README.md
+++ b/.github/README.md
@@ -16,6 +16,14 @@ Striae is a specialized, cloud-native platform designed to streamline forensic f
 
 [![Stephen J. Lu](https://github.com/StephenJLu.png?size=50)](https://github.com/StephenJLu)
 
+## 📝 License & IP
+
+Licensed under the [Apache License 2.0](https://github.com/striae-org/striae/blob/master/LICENSE).
+
+### Patent Notice
+
+One or more methods, systems, or features of the Striae platform are the subject of a pending patent application. Open-source code made available by Striae is licensed under the Apache 2.0 license, which includes a patent license grant for the licensed code. No patent rights beyond those expressly granted by the applicable open-source license are conveyed by use of this platform. Additional details are available in the [NOTICE](https://github.com/striae-org/striae/blob/master/NOTICE) file.
+
 ---
 
 ## 📋 Changelog

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ For deep implementation details, use the wiki docs.
 ## Scope and Architecture Snapshot
 
 - Frontend: React Router app in `app/`, deployed with Cloudflare Pages.
-- Workers: `audit`, `data`, `image`, `lists`, `pdf`, and `user` in `workers/`.
+- Workers: `audit`, `data`, `files`, `image`, `lists`, `pdf`, and `user` in `workers/`.
 - Data services: Firebase Auth plus Cloudflare KV and R2.
 - Config sources:
   - App runtime: `app/config/config.json`

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,30 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow
+# permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/striae-org/striae/blob/master/.github/CLA.md'
+          branch: 'master'
+          allowlist: dependabot[bot],bot*
+          lock-pullrequest-aftermerge: false

--- a/NOTICE
+++ b/NOTICE
@@ -7,6 +7,9 @@ automated report generation.
 
 Copyright (c) 2025 Stephen J. Lu
 
+Patent Pending: Application No. 64/110,670, Title: "Software configured
+for forensic firearms verification", Type: Utility under 35 U.S.C. 111(b).
+
 This product includes third-party software components that are licensed
 separately by their respective copyright holders.
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,13 @@ Excluded (by design):
 - Use only example files as templates and provide real values in your own private environment.
 - Review release notes for security updates before deployment.
 
-## License
+## License & IP
 
-See `LICENSE`.
+See [LICENSE](https://github.com/striae-org/striae/blob/master/LICENSE).
+
+### Patent Notice
+
+One or more methods, systems, or features of the Striae platform are the subject of a pending patent application. Open-source code made available by Striae is licensed under the Apache 2.0 license, which includes a patent license grant for the licensed code. No patent rights beyond those expressly granted by the applicable open-source license are conveyed by use of this platform. Additional details are available in the [NOTICE](https://github.com/striae-org/striae/blob/master/NOTICE) file.
 
 ## Support
 


### PR DESCRIPTION
This pull request introduces a Contributor License Agreement (CLA) process, updates documentation to clarify licensing and patent status, and configures automation for CLA enforcement. The main changes ensure that all contributions are properly licensed and that contributors are informed about intellectual property and patent considerations.

**Contributor License Agreement and Automation:**

* Added a new `.github/CLA.md` file outlining the Individual Contributor License Agreement (CLA) terms and instructions for signing.
* Introduced a `.github/workflows/cla.yml` GitHub Actions workflow to automate CLA checks and signature tracking using the CLA Assistant bot.
* Updated `.github/CONTRIBUTING.md` to require signing the CLA and to explain the automated sign-off process.

**Licensing and Patent Notices:**

* Added explicit license and patent notice sections to `.github/README.md` and `README.md`, including links to the `LICENSE` and `NOTICE` files and details about the pending patent application. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R19-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R63)
* Updated the `NOTICE` file with the patent application number and description.

**Documentation Updates:**

* Corrected the worker service list in `.github/copilot-instructions.md` to include the `files` worker.