### PR TITLE
bump v10.2.4

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,4 +4,4 @@ Want to contribute to Striae? Please contact us at [dev@striae.org](mailto:dev@s
 
 ## Contributor License Agreement
 
-All contributions to Striae require signing the [Individual Contributor License Agreement](CLA.md). When you open your first pull request, the CLA Assistant bot will comment with sign-off instructions; simply reply with the requested text on your pull request to sign. Your signature is recorded automatically and covers all future contributions.
+All contributions to Striae require signing the [Individual Contributor License Agreement](https://github.com/striae-org/striae/blob/master/.github/CLA.md). When you open your first pull request, the CLA Assistant bot will comment with sign-off instructions; simply reply with the requested text on your pull request to sign. Your signature is recorded automatically and covers all future contributions.

--- a/.github/README.md
+++ b/.github/README.md
@@ -28,6 +28,12 @@ One or more methods, systems, or features of the Striae platform are the subject
 
 ## 📋 Changelog
 
+## [2026-08-24] - *[Patch Release v10.2.4](https://github.com/striae-org/striae/releases/tag/v10.2.4)* — *Patent Notice, CLA, and Contributor Signature Workflow*
+
+- **⚖️ Patent Notice** - Renamed the `License` section to `License & IP` and added a `Patent Notice` subsection to `README.md`/`.github/README.md`, plus a `Patent Pending` line (Application No. 64/110,670) to the top-level `NOTICE` file.
+- **📄 Contributor License Agreement** - Added `.github/CLA.md`, an Individual Contributor License Agreement covering copyright and patent license grants, and a GitHub Actions workflow (`.github/workflows/cla.yml`) that has contributors sign off via pull request comment, recording signatures on a dedicated `cla-signatures` branch.
+- **🤝 Contributing Guide Update** - `.github/CONTRIBUTING.md` now documents the CLA requirement and links to the signed agreement.
+
 ## [2026-08-23] - *[Patch Release v10.2.3](https://github.com/striae-org/striae/releases/tag/v10.2.3)* — *License and Copyright Headers*
 
 - **📜 License and Copyright Header Rollout** - Added SPDX license and copyright headers (`Copyright (c) 2025 Stephen J. Lu`, `SPDX-License-Identifier: Apache-2.0`) to 337 in-scope source files across `app/`, `workers/`, `functions/`, `shared/`, `scripts/`, and eligible root-level config files.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported |
 | ------- | --------- |
-| v10.2.3 | :white_check_mark: |
+| v10.2.4 | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/.github/release-notes/RELEASE_NOTES_v10.2.4.md
+++ b/.github/release-notes/RELEASE_NOTES_v10.2.4.md
@@ -1,0 +1,36 @@
+# Striae Release Notes - v10.2.4
+
+**Release Date**: August 24, 2026
+**Period**: August 24, 2026 (same-day)
+**Total Commits**: 4 (non-merge since the v10.2.3 release)
+
+## Patch Release - Patent Notice, CLA, and Contributor Signature Workflow
+
+## Summary
+
+v10.2.4 is a small, same-day legal/repository-hygiene patch. It adds patent-pending notices to `README.md`/`.github/README.md` and `NOTICE`, introduces an Individual Contributor License Agreement (CLA), and wires up a GitHub Actions workflow so contributors sign the CLA automatically via pull request comments. No application behavior, worker logic, or API contracts changed.
+
+## Detailed Changes
+
+### Patent Notice (Legal)
+
+- **README Patent Notice** - Renamed the `License` section to `License & IP` in `README.md` and `.github/README.md`, linked directly to the `LICENSE` file, and added a `Patent Notice` subsection clarifying that one or more methods, systems, or features of the Striae platform are the subject of a pending patent application, that the Apache 2.0 license includes a patent license grant for the licensed code, and that no patent rights beyond those expressly granted are conveyed by use of the platform.
+- **NOTICE Update** - Added a `Patent Pending` line to the top-level `NOTICE` file referencing Application No. 64/110,670 ("Software configured for forensic firearms verification", Utility under 35 U.S.C. 111(b)).
+
+### Contributor License Agreement (Repository Hygiene)
+
+- **New CLA Document** - Added `.github/CLA.md`, an Individual Contributor License Agreement covering copyright and patent license grants from contributors, retained ownership, representations, and a sign-off procedure via pull request comment.
+- **CLA Assistant Workflow** - Added `.github/workflows/cla.yml` using `contributor-assistant/github-action@v2.6.1`, triggered on `issue_comment` and `pull_request_target` events, storing recorded signatures on the `cla-signatures` branch at `signatures/version1/cla.json`.
+- **Contributing Guide Update** - `.github/CONTRIBUTING.md` now documents the CLA requirement and links to `CLA.md`, with the link updated to an absolute GitHub URL for correct resolution outside the repository root.
+
+## Release Statistics
+
+- **Baseline**: .github/release-notes/RELEASE_NOTES_v10.2.3.md
+- **Commits Included**: 4 (non-merge commits from 2026-08-24)
+- **Build Status**: Passed (`npm run build`)
+- **Typecheck Status**: Passed (`npm run typecheck`)
+- **Lint Status**: Passed (`npm run lint`)
+
+## Closing Note
+
+v10.2.4 is a legal-and-repository-hygiene-only patch with no changes to application behavior, worker logic, storage formats, or public APIs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@striae-org/striae",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@striae-org/striae",
-      "version": "10.2.3",
+      "version": "10.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-router/cloudflare": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@striae-org/striae",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "private": false,
   "description": "Striae is a specialized, cloud-native platform designed to streamline forensic firearms identification by providing an intuitive environment for digital comparison image annotation, authenticated confirmations, and automated report generation.",
   "license": "Apache-2.0",

--- a/workers/audit-worker/package-lock.json
+++ b/workers/audit-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audit-worker",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audit-worker",
-      "version": "10.2.3",
+      "version": "10.2.4",
       "devDependencies": {
         "wrangler": "^4.125.0"
       }

--- a/workers/audit-worker/package.json
+++ b/workers/audit-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-worker",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/data-worker/package-lock.json
+++ b/workers/data-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-worker",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "data-worker",
-      "version": "10.2.3",
+      "version": "10.2.4",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.22.0",
         "wrangler": "^4.125.0"

--- a/workers/data-worker/package.json
+++ b/workers/data-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-worker",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/files-worker/package-lock.json
+++ b/workers/files-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "files-worker",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "files-worker",
-      "version": "10.2.3",
+      "version": "10.2.4",
       "devDependencies": {
         "wrangler": "^4.125.0"
       }

--- a/workers/files-worker/package.json
+++ b/workers/files-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "files-worker",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/image-worker/package-lock.json
+++ b/workers/image-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-worker",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-worker",
-      "version": "10.2.3",
+      "version": "10.2.4",
       "devDependencies": {
         "wrangler": "^4.125.0"
       }

--- a/workers/image-worker/package.json
+++ b/workers/image-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-worker",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/lists-worker/package-lock.json
+++ b/workers/lists-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lists-worker",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lists-worker",
-      "version": "10.2.3",
+      "version": "10.2.4",
       "devDependencies": {
         "wrangler": "^4.125.0"
       }

--- a/workers/lists-worker/package.json
+++ b/workers/lists-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lists-worker",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/pdf-worker/package-lock.json
+++ b/workers/pdf-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdf-worker",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-worker",
-      "version": "10.2.3",
+      "version": "10.2.4",
       "devDependencies": {
         "wrangler": "^4.125.0"
       }

--- a/workers/pdf-worker/package.json
+++ b/workers/pdf-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-worker",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "private": true,
   "scripts": {
     "generate:assets": "node scripts/generate-assets.js",

--- a/workers/user-worker/package-lock.json
+++ b/workers/user-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "user-worker",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "user-worker",
-      "version": "10.2.3",
+      "version": "10.2.4",
       "devDependencies": {
         "wrangler": "^4.125.0"
       }

--- a/workers/user-worker/package.json
+++ b/workers/user-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-worker",
-  "version": "10.2.3",
+  "version": "10.2.4",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",


### PR DESCRIPTION
This pull request is a legal and repository hygiene patch for the v10.2.4 release. It introduces patent-pending notices, adds a Contributor License Agreement (CLA), and sets up an automated CLA signature workflow for contributors. There are no changes to application behavior, worker logic, or public APIs. The release also includes routine version bumps across all worker packages.

**Legal and Documentation Updates:**

* Added a `Patent Notice` subsection to `README.md` and `.github/README.md`, clarified the Apache 2.0 patent license grant, and referenced a pending patent application. The top-level `NOTICE` file now includes a `Patent Pending` line. (`[.github/README.mdR31-R36](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R31-R36)`)
* Renamed the `License` section to `License & IP` and ensured the `LICENSE` file is linked directly. (`[.github/README.mdR31-R36](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R31-R36)`)

**Contributor License Agreement and Workflow:**

* Added `.github/CLA.md`, an Individual Contributor License Agreement covering copyright and patent license grants, and documented the CLA requirement in `.github/CONTRIBUTING.md` with an updated absolute link. (`[[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R31-R36)`, `[[2]](diffhunk://#diff-98e64bc1cd2db9333c6effe87bbe0d6dfe8714aba4c6bde45aa037fe0796e44cL7-R7)`)
* Introduced a GitHub Actions workflow (`.github/workflows/cla.yml`) that records CLA signatures via pull request comments, storing them on the `cla-signatures` branch. (`[.github/README.mdR31-R36](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R31-R36)`)

**Release and Versioning:**

* Created `.github/release-notes/RELEASE_NOTES_v10.2.4.md` summarizing the legal/repository changes and confirming no code or API changes. (`[.github/release-notes/RELEASE_NOTES_v10.2.4.mdR1-R36](diffhunk://#diff-a126fabed4221401630cd3abfb23d47ca4367e3a64959aa5bf58099e717bfa4cR1-R36)`)
* Bumped version numbers from `10.2.3` to `10.2.4` in `package.json`, all worker `package.json` files, and associated `package-lock.json` files to reflect the new release. (`[[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)`, `[[2]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L3-R9)`, `[[3]](diffhunk://#diff-d16fb6b09f684160054b5c0e353e35f63f00651bc94bcbcaf521437dfccd9fc9L3-R3)`, `[[4]](diffhunk://#diff-6e5e36a60c0d36c5b64aa73374f62c57efbd072023660e8d0aec12a4280248c9L3-R9)`, `[[5]](diffhunk://#diff-25a913066a7fe613d4b06888c5c4429d3115d670e3a47c1e0093f93ac69b0bc6L3-R3)`, `[[6]](diffhunk://#diff-2e570683d145e3fa7b1063ce1d683872c51eecd3ea3a8fe5dd3d440205c04471L3-R9)`, `[[7]](diffhunk://#diff-817a8feb4248f5365f365346c5b6db440c0421d1e566446da782d17d3d39d3edL3-R3)`, `[[8]](diffhunk://#diff-8aaa33f9d5640156d7cec29c58ba66ec9c932b4c106dc397b9558af952100cebL3-R9)`, `[[9]](diffhunk://#diff-6b488296f955b235077b13eb5a4be1d4fbec35413644445e150b93f1800aec71L3-R3)`, `[[10]](diffhunk://#diff-237cd9065b0326cd283962fedd9d0c680814dedcbf11f08de91d6ebe061c05d0L3-R9)`, `[[11]](diffhunk://#diff-b4e4eeabc3f819e9d58d3f53bef732bdda3c7b4e920ce7efa299a59a6720f13bL3-R3)`, `[[12]](diffhunk://#diff-1d4408399474dc9865a67a3928dc47144f925b807fcb91fff6d733905d621e66L3-R9)`, `[[13]](diffhunk://#diff-0e896c71a77804a30199ade801c401da5f6343c86e21a0e184974feb2a80a941L3-R3)`, `[[14]](diffhunk://#diff-4f2f3beba65f88db2a2cf66fe5915d9f3fd6d730ef00036a75bf9c3d11c2dc7bL3-R9)`, `[[15]](diffhunk://#diff-0c2ca2d4f71077b08e99fbcf3b51ff4afd93456ac56a1cfa279ef8ce62e9b445L3-R3)`)
* Updated `.github/SECURITY.md` to indicate support for v10.2.4. (`[.github/SECURITY.mdL7-R7](diffhunk://#diff-ac3050733d58345444c27d37c6247ef260ad992bcb02782feea43fb580106079L7-R7)`)