### PR TITLE
bump v10.2.5

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -28,6 +28,11 @@ One or more methods, systems, or features of the Striae platform are the subject
 
 ## 📋 Changelog
 
+## [2026-08-25] - *[Patch Release v10.2.5](https://github.com/striae-org/striae/releases/tag/v10.2.5)* — *RSA-3072 Key Rotation Migration + Dependency Maintenance*
+
+- **🔐 RSA-3072 Key Rotation Migration (Security)** - Added a shared `RSA_KEY_MODULUS_LENGTH=3072` constant in `scripts/deploy-config/modules/keys.sh` and updated all four self-generated RSA key-pair routines (manifest signing, export encryption, data-at-rest encryption, user KV encryption) to use RSA-3072 for newly generated keys instead of RSA-2048. Existing deployed key material is unaffected until rotated.
+- **📦 Dependency Maintenance** - Bumped `@cloudflare/vite-plugin`, `@cloudflare/workers-types`, and `wrangler` (`4.126.0`) at the root and across all six workers, with matching compatibility-date refreshes to `2026-08-25`.
+
 ## [2026-08-24] - *[Patch Release v10.2.4](https://github.com/striae-org/striae/releases/tag/v10.2.4)* — *Patent Notice, CLA, and Contributor Signature Workflow*
 
 - **⚖️ Patent Notice** - Renamed the `License` section to `License & IP` and added a `Patent Notice` subsection to `README.md`/`.github/README.md`, plus a `Patent Pending` line (Application No. 64/110,670) to the top-level `NOTICE` file.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported |
 | ------- | --------- |
-| v10.2.4 | :white_check_mark: |
+| v10.2.5 | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/.github/release-notes/RELEASE_NOTES_v10.2.5.md
+++ b/.github/release-notes/RELEASE_NOTES_v10.2.5.md
@@ -1,0 +1,36 @@
+# Striae Release Notes - v10.2.5
+
+**Release Date**: August 25, 2026
+**Period**: August 25, 2026 (same-day)
+**Total Commits**: 3 (non-merge since the v10.2.4 release)
+
+## Patch Release - RSA-3072 Key Rotation Migration + Dependency Maintenance
+
+## Summary
+
+v10.2.5 is a same-day security-hardening patch. It raises the modulus length used for all future self-generated RSA key pairs (manifest signing, export encryption, data-at-rest encryption, and user KV encryption) from RSA-2048 to RSA-3072, and refreshes a small set of root and worker dependencies. No API contracts, storage formats, or existing deployed keys are affected; the change governs key generation for future rotations only.
+
+## Detailed Changes
+
+### RSA-3072 Key Rotation Migration (Security)
+
+- **Shared Modulus Length Constant** - Added a single `RSA_KEY_MODULUS_LENGTH=3072` variable in `scripts/deploy-config/modules/keys.sh` and updated all four self-generated RSA key-pair generation routines (`generate_manifest_signing_key_pair`, `generate_export_encryption_key_pair`, `generate_data_at_rest_encryption_key_pair`, `generate_user_kv_encryption_key_pair`) to reference it instead of a hardcoded `modulusLength: 2048`.
+- **Scope** - This change affects only newly generated key pairs going forward (fresh deploys and future key rotations via deploy-config). Existing already-deployed RSA-2048 key material continues to function unchanged until rotated.
+
+### Dependency and Compatibility Maintenance
+
+- **Root Dependency Bumps** - Bumped `@cloudflare/vite-plugin` (`1.53.1` → `1.54.0`), `@cloudflare/workers-types` (`5.20260823.1` → `5.20260825.1`), and `wrangler` (`4.125.0` → `4.126.0`) in the root `package.json`.
+- **Worker Dependency Bumps** - Bumped `wrangler` to `4.126.0` across all six workers (`audit-worker`, `data-worker`, `files-worker`, `image-worker`, `lists-worker`, `pdf-worker`, `user-worker`) with matching `package-lock.json` refreshes.
+- **Compatibility-Date Refresh** - Updated `compatibility_date` to `2026-08-25` in `wrangler.toml.example` and all worker `wrangler.jsonc.example` files.
+
+## Release Statistics
+
+- **Baseline**: .github/release-notes/RELEASE_NOTES_v10.2.4.md
+- **Commits Included**: 3 (non-merge commits from 2026-08-25)
+- **Build Status**: Passed (`npm run build`)
+- **Typecheck Status**: Passed (`npm run typecheck`)
+- **Lint Status**: Passed (`npm run lint`)
+
+## Closing Note
+
+v10.2.5 is a security-hardening and dependency-maintenance patch. Existing deployed RSA-2048 keys are unaffected; the RSA-3072 modulus length applies to newly generated key pairs from this point forward.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@striae-org/striae",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@striae-org/striae",
-      "version": "10.2.4",
+      "version": "10.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-router/cloudflare": "^8.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
         "react-router": "^8.3.0"
       },
       "devDependencies": {
-        "@cloudflare/vite-plugin": "^1.53.1",
+        "@cloudflare/vite-plugin": "^1.54.0",
         "@cloudflare/vitest-pool-workers": "^0.22.0",
-        "@cloudflare/workers-types": "^5.20260823.1",
+        "@cloudflare/workers-types": "^5.20260825.1",
         "@eslint-react/eslint-plugin": "^5.18.6",
         "@eslint/js": "^10.0.1",
         "@react-router/dev": "^8.3.0",
@@ -42,7 +42,7 @@
         "typescript-eslint": "^8.68.0",
         "vite": "^8.2.2",
         "vitest": "^4.1.11",
-        "wrangler": "^4.125.0"
+        "wrangler": "^4.126.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -552,17 +552,17 @@
       }
     },
     "node_modules/@cloudflare/vite-plugin": {
-      "version": "1.53.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.53.1.tgz",
-      "integrity": "sha512-eem83hLppqJAJUi4Nh5L6LQ5bC6ASSzN2zoI3ryooroLQIqhNJxx2ZgX/52CdAaF6emloJi/+tizEiVLsUKs+A==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.54.0.tgz",
+      "integrity": "sha512-9jQEA7t4QvjsLbdBPwtTquLMFi5XRy16/6CBJ0BbOgWqx3vPWv0gpwD5attTsbbQq1bL52cTKZmZLqgZCPSViQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cloudflare/unenv-preset": "2.16.1",
-        "miniflare": "5.20260820.0-alpha",
+        "miniflare": "5.20260825.0-alpha",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260820.1",
-        "wrangler": "4.125.0",
+        "workerd": "1.20260825.1",
+        "wrangler": "4.126.0",
         "ws": "8.21.0"
       },
       "bin": {
@@ -570,7 +570,7 @@
       },
       "peerDependencies": {
         "vite": "^6.1.0 || ^7.0.0 || ^8.0.0",
-        "wrangler": "^4.125.0"
+        "wrangler": "^4.126.0"
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers": {
@@ -753,9 +753,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260820.1.tgz",
-      "integrity": "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260825.1.tgz",
+      "integrity": "sha512-oHu38dwaUuzAilyTb0QkQ1YxU/kzqzIQybCvQKAhiK1CGtQS9h0MmjIZYogv3g8cFGGY2k+Wxs0wV9hHK8z78g==",
       "cpu": [
         "x64"
       ],
@@ -770,9 +770,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-ak5zh8YGEjxQQ78bVo7gzU+tcg2fSFxMIjOPZtWk56a/rIYLbGu6ECcliqnYfMUlragg68H0JuVpfdr3BR5Alw==",
       "cpu": [
         "arm64"
       ],
@@ -787,9 +787,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260820.1.tgz",
-      "integrity": "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260825.1.tgz",
+      "integrity": "sha512-bNQvzz6NemWAwixDRz1fQa5T+E5lS4xpB7A/H/72ULxrjVpHmq8CGFPSbdmRp3dvgBjZTgp7wHdGLISLSVd9Gg==",
       "cpu": [
         "x64"
       ],
@@ -804,9 +804,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-a5E61YsnNCHHQMnmYsbVXInzeYqFqAMwm/wo16dWW4klXDr6T1bm7u1h5G7ZkxVM7+rtc69oe0yVHjDEqzpYVg==",
       "cpu": [
         "arm64"
       ],
@@ -821,9 +821,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260820.1.tgz",
-      "integrity": "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260825.1.tgz",
+      "integrity": "sha512-EokzVY2suzRSzeURi2HpHnySR5mo6aF5V1klFIqFOZp2YJyXXTI8AvQgYzhlmGTZY3LNL41jjkUQunOM2OErgQ==",
       "cpu": [
         "x64"
       ],
@@ -838,9 +838,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "5.20260823.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260823.1.tgz",
-      "integrity": "sha512-HdBVDR/gecQ5QwB+DZ9kB5yjNZLS85fe8bMB2K/k0xmCvaoMlAFrQQGLaCBYR00j+i9aTkQzwfrPInVZwlMPwQ==",
+      "version": "5.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260825.1.tgz",
+      "integrity": "sha512-/XZntbK+BlJWC5jxkaDNhnDLr2Bf2627sZ6VMrxqKrnc84pc6gNu5NdAyaTkZn1LzQVFIa3SL7V/7veLF59P7w==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -7830,16 +7830,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "5.20260820.0-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260820.0-alpha.tgz",
-      "integrity": "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ==",
+      "version": "5.20260825.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260825.0-alpha.tgz",
+      "integrity": "sha512-ZwlF6LuX43ilx9EwMRDKHenoGXiNdcKSyGx5aPaJhuozujVZasb2lRR7t3ojJZSnVzwDPsBBYCu8lLnc+/KIgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
         "undici": "7.29.0",
-        "workerd": "1.20260820.1",
+        "workerd": "1.20260825.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -9681,9 +9681,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260820.1.tgz",
-      "integrity": "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260825.1.tgz",
+      "integrity": "sha512-ccS6TEaaRxgONKawiYGnFYUVGfr2pmN1b7mrNtw0ADVhFaYsEIVoCHnQ4UjhM9EJDzuaNgAWFY82nzVrjWpuOA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -9694,17 +9694,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260820.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260820.1",
-        "@cloudflare/workerd-linux-64": "1.20260820.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260820.1",
-        "@cloudflare/workerd-windows-64": "1.20260820.1"
+        "@cloudflare/workerd-darwin-64": "1.20260825.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260825.1",
+        "@cloudflare/workerd-linux-64": "1.20260825.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260825.1",
+        "@cloudflare/workerd-windows-64": "1.20260825.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.125.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.125.0.tgz",
-      "integrity": "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg==",
+      "version": "4.126.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.126.0.tgz",
+      "integrity": "sha512-glDq/nxaeQwue0XMIeupfwlu2jVxnFs+wjDFT71DQuURN5LsVdCwu0Af/1ep10U5xr1rKPGhHDEDkKG9nxE/dg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -9712,10 +9712,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260820.0-alpha",
+        "miniflare": "5.20260825.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260820.1"
+        "workerd": "1.20260825.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -9729,7 +9729,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260820.1"
+        "@cloudflare/workers-types": "^5.20260825.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/package.json
+++ b/package.json
@@ -145,9 +145,9 @@
     "react-router": "^8.3.0"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "^1.53.1",
+    "@cloudflare/vite-plugin": "^1.54.0",
     "@cloudflare/vitest-pool-workers": "^0.22.0",
-    "@cloudflare/workers-types": "^5.20260823.1",
+    "@cloudflare/workers-types": "^5.20260825.1",
     "@eslint-react/eslint-plugin": "^5.18.6",
     "@eslint/js": "^10.0.1",
     "@react-router/dev": "^8.3.0",
@@ -168,7 +168,7 @@
     "typescript-eslint": "^8.68.0",
     "vite": "^8.2.2",
     "vitest": "^4.1.11",
-    "wrangler": "^4.125.0"
+    "wrangler": "^4.126.0"
   },
   "overrides": {
     "brace-expansion": "^5.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@striae-org/striae",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "private": false,
   "description": "Striae is a specialized, cloud-native platform designed to streamline forensic firearms identification by providing an intuitive environment for digital comparison image annotation, authenticated confirmations, and automated report generation.",
   "license": "Apache-2.0",

--- a/scripts/deploy-config/modules/keys.sh
+++ b/scripts/deploy-config/modules/keys.sh
@@ -3,6 +3,10 @@
 # Copyright (c) 2025 Stephen J. Lu
 # SPDX-License-Identifier: Apache-2.0
 
+# Shared modulus length for all self-generated RSA key pairs (manifest signing,
+# export encryption, data-at-rest encryption, user KV encryption).
+RSA_KEY_MODULUS_LENGTH=3072
+
 is_admin_service_placeholder() {
     local value="$1"
     local normalized=$(echo "$value" | tr '[:upper:]' '[:lower:]')
@@ -77,7 +81,7 @@ generate_manifest_signing_key_pair() {
     private_key_file=$(mktemp)
     public_key_file=$(mktemp)
 
-    if ! node -e "const { generateKeyPairSync } = require('crypto'); const fs = require('fs'); const pair = generateKeyPairSync('rsa', { modulusLength: 2048, publicKeyEncoding: { type: 'spki', format: 'pem' }, privateKeyEncoding: { type: 'pkcs8', format: 'pem' } }); fs.writeFileSync(process.argv[1], pair.privateKey, 'utf8'); fs.writeFileSync(process.argv[2], pair.publicKey, 'utf8');" "$private_key_file" "$public_key_file"; then
+    if ! node -e "const { generateKeyPairSync } = require('crypto'); const fs = require('fs'); const pair = generateKeyPairSync('rsa', { modulusLength: ${RSA_KEY_MODULUS_LENGTH}, publicKeyEncoding: { type: 'spki', format: 'pem' }, privateKeyEncoding: { type: 'pkcs8', format: 'pem' } }); fs.writeFileSync(process.argv[1], pair.privateKey, 'utf8'); fs.writeFileSync(process.argv[2], pair.publicKey, 'utf8');" "$private_key_file" "$public_key_file"; then
         rm -f "$private_key_file" "$public_key_file"
         return 1
     fi
@@ -162,7 +166,7 @@ generate_export_encryption_key_pair() {
     private_key_file=$(mktemp)
     public_key_file=$(mktemp)
 
-    if ! node -e "const { generateKeyPairSync } = require('crypto'); const fs = require('fs'); const pair = generateKeyPairSync('rsa', { modulusLength: 2048, publicKeyEncoding: { type: 'spki', format: 'pem' }, privateKeyEncoding: { type: 'pkcs8', format: 'pem' } }); fs.writeFileSync(process.argv[1], pair.privateKey, 'utf8'); fs.writeFileSync(process.argv[2], pair.publicKey, 'utf8');" "$private_key_file" "$public_key_file"; then
+    if ! node -e "const { generateKeyPairSync } = require('crypto'); const fs = require('fs'); const pair = generateKeyPairSync('rsa', { modulusLength: ${RSA_KEY_MODULUS_LENGTH}, publicKeyEncoding: { type: 'spki', format: 'pem' }, privateKeyEncoding: { type: 'pkcs8', format: 'pem' } }); fs.writeFileSync(process.argv[1], pair.privateKey, 'utf8'); fs.writeFileSync(process.argv[2], pair.publicKey, 'utf8');" "$private_key_file" "$public_key_file"; then
         rm -f "$private_key_file" "$public_key_file"
         return 1
     fi
@@ -247,7 +251,7 @@ generate_data_at_rest_encryption_key_pair() {
     private_key_file=$(mktemp)
     public_key_file=$(mktemp)
 
-    if ! node -e "const { generateKeyPairSync } = require('crypto'); const fs = require('fs'); const pair = generateKeyPairSync('rsa', { modulusLength: 2048, publicKeyEncoding: { type: 'spki', format: 'pem' }, privateKeyEncoding: { type: 'pkcs8', format: 'pem' } }); fs.writeFileSync(process.argv[1], pair.privateKey, 'utf8'); fs.writeFileSync(process.argv[2], pair.publicKey, 'utf8');" "$private_key_file" "$public_key_file"; then
+    if ! node -e "const { generateKeyPairSync } = require('crypto'); const fs = require('fs'); const pair = generateKeyPairSync('rsa', { modulusLength: ${RSA_KEY_MODULUS_LENGTH}, publicKeyEncoding: { type: 'spki', format: 'pem' }, privateKeyEncoding: { type: 'pkcs8', format: 'pem' } }); fs.writeFileSync(process.argv[1], pair.privateKey, 'utf8'); fs.writeFileSync(process.argv[2], pair.publicKey, 'utf8');" "$private_key_file" "$public_key_file"; then
         rm -f "$private_key_file" "$public_key_file"
         return 1
     fi
@@ -279,7 +283,7 @@ generate_user_kv_encryption_key_pair() {
     private_key_file=$(mktemp)
     public_key_file=$(mktemp)
 
-    if ! node -e "const { generateKeyPairSync } = require('crypto'); const fs = require('fs'); const pair = generateKeyPairSync('rsa', { modulusLength: 2048, publicKeyEncoding: { type: 'spki', format: 'pem' }, privateKeyEncoding: { type: 'pkcs8', format: 'pem' } }); fs.writeFileSync(process.argv[1], pair.privateKey, 'utf8'); fs.writeFileSync(process.argv[2], pair.publicKey, 'utf8');" "$private_key_file" "$public_key_file"; then
+    if ! node -e "const { generateKeyPairSync } = require('crypto'); const fs = require('fs'); const pair = generateKeyPairSync('rsa', { modulusLength: ${RSA_KEY_MODULUS_LENGTH}, publicKeyEncoding: { type: 'spki', format: 'pem' }, privateKeyEncoding: { type: 'pkcs8', format: 'pem' } }); fs.writeFileSync(process.argv[1], pair.privateKey, 'utf8'); fs.writeFileSync(process.argv[2], pair.publicKey, 'utf8');" "$private_key_file" "$public_key_file"; then
         rm -f "$private_key_file" "$public_key_file"
         return 1
     fi

--- a/workers/audit-worker/package-lock.json
+++ b/workers/audit-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audit-worker",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audit-worker",
-      "version": "10.2.4",
+      "version": "10.2.5",
       "devDependencies": {
         "wrangler": "^4.126.0"
       }

--- a/workers/audit-worker/package-lock.json
+++ b/workers/audit-worker/package-lock.json
@@ -8,7 +8,7 @@
       "name": "audit-worker",
       "version": "10.2.4",
       "devDependencies": {
-        "wrangler": "^4.125.0"
+        "wrangler": "^4.126.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260820.1.tgz",
-      "integrity": "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260825.1.tgz",
+      "integrity": "sha512-oHu38dwaUuzAilyTb0QkQ1YxU/kzqzIQybCvQKAhiK1CGtQS9h0MmjIZYogv3g8cFGGY2k+Wxs0wV9hHK8z78g==",
       "cpu": [
         "x64"
       ],
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-ak5zh8YGEjxQQ78bVo7gzU+tcg2fSFxMIjOPZtWk56a/rIYLbGu6ECcliqnYfMUlragg68H0JuVpfdr3BR5Alw==",
       "cpu": [
         "arm64"
       ],
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260820.1.tgz",
-      "integrity": "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260825.1.tgz",
+      "integrity": "sha512-bNQvzz6NemWAwixDRz1fQa5T+E5lS4xpB7A/H/72ULxrjVpHmq8CGFPSbdmRp3dvgBjZTgp7wHdGLISLSVd9Gg==",
       "cpu": [
         "x64"
       ],
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-a5E61YsnNCHHQMnmYsbVXInzeYqFqAMwm/wo16dWW4klXDr6T1bm7u1h5G7ZkxVM7+rtc69oe0yVHjDEqzpYVg==",
       "cpu": [
         "arm64"
       ],
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260820.1.tgz",
-      "integrity": "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260825.1.tgz",
+      "integrity": "sha512-EokzVY2suzRSzeURi2HpHnySR5mo6aF5V1klFIqFOZp2YJyXXTI8AvQgYzhlmGTZY3LNL41jjkUQunOM2OErgQ==",
       "cpu": [
         "x64"
       ],
@@ -1349,16 +1349,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "5.20260820.0-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260820.0-alpha.tgz",
-      "integrity": "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ==",
+      "version": "5.20260825.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260825.0-alpha.tgz",
+      "integrity": "sha512-ZwlF6LuX43ilx9EwMRDKHenoGXiNdcKSyGx5aPaJhuozujVZasb2lRR7t3ojJZSnVzwDPsBBYCu8lLnc+/KIgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
         "undici": "7.29.0",
-        "workerd": "1.20260820.1",
+        "workerd": "1.20260825.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260820.1.tgz",
-      "integrity": "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260825.1.tgz",
+      "integrity": "sha512-ccS6TEaaRxgONKawiYGnFYUVGfr2pmN1b7mrNtw0ADVhFaYsEIVoCHnQ4UjhM9EJDzuaNgAWFY82nzVrjWpuOA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1493,17 +1493,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260820.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260820.1",
-        "@cloudflare/workerd-linux-64": "1.20260820.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260820.1",
-        "@cloudflare/workerd-windows-64": "1.20260820.1"
+        "@cloudflare/workerd-darwin-64": "1.20260825.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260825.1",
+        "@cloudflare/workerd-linux-64": "1.20260825.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260825.1",
+        "@cloudflare/workerd-windows-64": "1.20260825.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.125.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.125.0.tgz",
-      "integrity": "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg==",
+      "version": "4.126.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.126.0.tgz",
+      "integrity": "sha512-glDq/nxaeQwue0XMIeupfwlu2jVxnFs+wjDFT71DQuURN5LsVdCwu0Af/1ep10U5xr1rKPGhHDEDkKG9nxE/dg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1511,10 +1511,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260820.0-alpha",
+        "miniflare": "5.20260825.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260820.1"
+        "workerd": "1.20260825.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -1528,7 +1528,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260820.1"
+        "@cloudflare/workers-types": "^5.20260825.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/workers/audit-worker/package.json
+++ b/workers/audit-worker/package.json
@@ -8,7 +8,7 @@
     "start": "wrangler dev"
   },
   "devDependencies": {
-    "wrangler": "^4.125.0"
+    "wrangler": "^4.126.0"
   },
   "allowScripts": {
     "esbuild": true,

--- a/workers/audit-worker/package.json
+++ b/workers/audit-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-worker",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/audit-worker/wrangler.jsonc.example
+++ b/workers/audit-worker/wrangler.jsonc.example
@@ -3,7 +3,7 @@
   "account_id": "ACCOUNT_ID",
   "main": "src/audit-worker.ts",
   "workers_dev": false,
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/data-worker/package-lock.json
+++ b/workers/data-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-worker",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "data-worker",
-      "version": "10.2.4",
+      "version": "10.2.5",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.22.0",
         "wrangler": "^4.126.0"

--- a/workers/data-worker/package-lock.json
+++ b/workers/data-worker/package-lock.json
@@ -9,7 +9,7 @@
       "version": "10.2.4",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.22.0",
-        "wrangler": "^4.125.0"
+        "wrangler": "^4.126.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -2776,9 +2776,9 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.125.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.125.0.tgz",
-      "integrity": "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg==",
+      "version": "4.126.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.126.0.tgz",
+      "integrity": "sha512-glDq/nxaeQwue0XMIeupfwlu2jVxnFs+wjDFT71DQuURN5LsVdCwu0Af/1ep10U5xr1rKPGhHDEDkKG9nxE/dg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -2786,10 +2786,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260820.0-alpha",
+        "miniflare": "5.20260825.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260820.1"
+        "workerd": "1.20260825.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -2803,7 +2803,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260820.1"
+        "@cloudflare/workers-types": "^5.20260825.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -2812,9 +2812,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260820.1.tgz",
-      "integrity": "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260825.1.tgz",
+      "integrity": "sha512-oHu38dwaUuzAilyTb0QkQ1YxU/kzqzIQybCvQKAhiK1CGtQS9h0MmjIZYogv3g8cFGGY2k+Wxs0wV9hHK8z78g==",
       "cpu": [
         "x64"
       ],
@@ -2829,9 +2829,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-ak5zh8YGEjxQQ78bVo7gzU+tcg2fSFxMIjOPZtWk56a/rIYLbGu6ECcliqnYfMUlragg68H0JuVpfdr3BR5Alw==",
       "cpu": [
         "arm64"
       ],
@@ -2846,9 +2846,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260820.1.tgz",
-      "integrity": "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260825.1.tgz",
+      "integrity": "sha512-bNQvzz6NemWAwixDRz1fQa5T+E5lS4xpB7A/H/72ULxrjVpHmq8CGFPSbdmRp3dvgBjZTgp7wHdGLISLSVd9Gg==",
       "cpu": [
         "x64"
       ],
@@ -2863,9 +2863,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-a5E61YsnNCHHQMnmYsbVXInzeYqFqAMwm/wo16dWW4klXDr6T1bm7u1h5G7ZkxVM7+rtc69oe0yVHjDEqzpYVg==",
       "cpu": [
         "arm64"
       ],
@@ -2880,9 +2880,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260820.1.tgz",
-      "integrity": "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260825.1.tgz",
+      "integrity": "sha512-EokzVY2suzRSzeURi2HpHnySR5mo6aF5V1klFIqFOZp2YJyXXTI8AvQgYzhlmGTZY3LNL41jjkUQunOM2OErgQ==",
       "cpu": [
         "x64"
       ],
@@ -2897,16 +2897,16 @@
       }
     },
     "node_modules/wrangler/node_modules/miniflare": {
-      "version": "5.20260820.0-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260820.0-alpha.tgz",
-      "integrity": "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ==",
+      "version": "5.20260825.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260825.0-alpha.tgz",
+      "integrity": "sha512-ZwlF6LuX43ilx9EwMRDKHenoGXiNdcKSyGx5aPaJhuozujVZasb2lRR7t3ojJZSnVzwDPsBBYCu8lLnc+/KIgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
         "undici": "7.29.0",
-        "workerd": "1.20260820.1",
+        "workerd": "1.20260825.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -2915,9 +2915,9 @@
       }
     },
     "node_modules/wrangler/node_modules/workerd": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260820.1.tgz",
-      "integrity": "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260825.1.tgz",
+      "integrity": "sha512-ccS6TEaaRxgONKawiYGnFYUVGfr2pmN1b7mrNtw0ADVhFaYsEIVoCHnQ4UjhM9EJDzuaNgAWFY82nzVrjWpuOA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -2928,11 +2928,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260820.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260820.1",
-        "@cloudflare/workerd-linux-64": "1.20260820.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260820.1",
-        "@cloudflare/workerd-windows-64": "1.20260820.1"
+        "@cloudflare/workerd-darwin-64": "1.20260825.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260825.1",
+        "@cloudflare/workerd-linux-64": "1.20260825.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260825.1",
+        "@cloudflare/workerd-windows-64": "1.20260825.1"
       }
     },
     "node_modules/ws": {

--- a/workers/data-worker/package.json
+++ b/workers/data-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-worker",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/data-worker/package.json
+++ b/workers/data-worker/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.22.0",
-    "wrangler": "^4.125.0"
+    "wrangler": "^4.126.0"
   },
   "allowScripts": {
     "esbuild": true,

--- a/workers/data-worker/wrangler.jsonc.example
+++ b/workers/data-worker/wrangler.jsonc.example
@@ -3,7 +3,7 @@
   "account_id": "ACCOUNT_ID",
   "main": "src/data-worker.ts",
   "workers_dev": false,
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/files-worker/package-lock.json
+++ b/workers/files-worker/package-lock.json
@@ -8,7 +8,7 @@
       "name": "files-worker",
       "version": "10.2.4",
       "devDependencies": {
-        "wrangler": "^4.125.0"
+        "wrangler": "^4.126.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260820.1.tgz",
-      "integrity": "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260825.1.tgz",
+      "integrity": "sha512-oHu38dwaUuzAilyTb0QkQ1YxU/kzqzIQybCvQKAhiK1CGtQS9h0MmjIZYogv3g8cFGGY2k+Wxs0wV9hHK8z78g==",
       "cpu": [
         "x64"
       ],
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-ak5zh8YGEjxQQ78bVo7gzU+tcg2fSFxMIjOPZtWk56a/rIYLbGu6ECcliqnYfMUlragg68H0JuVpfdr3BR5Alw==",
       "cpu": [
         "arm64"
       ],
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260820.1.tgz",
-      "integrity": "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260825.1.tgz",
+      "integrity": "sha512-bNQvzz6NemWAwixDRz1fQa5T+E5lS4xpB7A/H/72ULxrjVpHmq8CGFPSbdmRp3dvgBjZTgp7wHdGLISLSVd9Gg==",
       "cpu": [
         "x64"
       ],
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-a5E61YsnNCHHQMnmYsbVXInzeYqFqAMwm/wo16dWW4klXDr6T1bm7u1h5G7ZkxVM7+rtc69oe0yVHjDEqzpYVg==",
       "cpu": [
         "arm64"
       ],
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260820.1.tgz",
-      "integrity": "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260825.1.tgz",
+      "integrity": "sha512-EokzVY2suzRSzeURi2HpHnySR5mo6aF5V1klFIqFOZp2YJyXXTI8AvQgYzhlmGTZY3LNL41jjkUQunOM2OErgQ==",
       "cpu": [
         "x64"
       ],
@@ -1349,16 +1349,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "5.20260820.0-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260820.0-alpha.tgz",
-      "integrity": "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ==",
+      "version": "5.20260825.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260825.0-alpha.tgz",
+      "integrity": "sha512-ZwlF6LuX43ilx9EwMRDKHenoGXiNdcKSyGx5aPaJhuozujVZasb2lRR7t3ojJZSnVzwDPsBBYCu8lLnc+/KIgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
         "undici": "7.29.0",
-        "workerd": "1.20260820.1",
+        "workerd": "1.20260825.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260820.1.tgz",
-      "integrity": "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260825.1.tgz",
+      "integrity": "sha512-ccS6TEaaRxgONKawiYGnFYUVGfr2pmN1b7mrNtw0ADVhFaYsEIVoCHnQ4UjhM9EJDzuaNgAWFY82nzVrjWpuOA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1493,17 +1493,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260820.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260820.1",
-        "@cloudflare/workerd-linux-64": "1.20260820.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260820.1",
-        "@cloudflare/workerd-windows-64": "1.20260820.1"
+        "@cloudflare/workerd-darwin-64": "1.20260825.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260825.1",
+        "@cloudflare/workerd-linux-64": "1.20260825.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260825.1",
+        "@cloudflare/workerd-windows-64": "1.20260825.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.125.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.125.0.tgz",
-      "integrity": "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg==",
+      "version": "4.126.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.126.0.tgz",
+      "integrity": "sha512-glDq/nxaeQwue0XMIeupfwlu2jVxnFs+wjDFT71DQuURN5LsVdCwu0Af/1ep10U5xr1rKPGhHDEDkKG9nxE/dg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1511,10 +1511,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260820.0-alpha",
+        "miniflare": "5.20260825.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260820.1"
+        "workerd": "1.20260825.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -1528,7 +1528,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260820.1"
+        "@cloudflare/workers-types": "^5.20260825.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/workers/files-worker/package-lock.json
+++ b/workers/files-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "files-worker",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "files-worker",
-      "version": "10.2.4",
+      "version": "10.2.5",
       "devDependencies": {
         "wrangler": "^4.126.0"
       }

--- a/workers/files-worker/package.json
+++ b/workers/files-worker/package.json
@@ -8,7 +8,7 @@
     "start": "wrangler dev"
   },
   "devDependencies": {
-    "wrangler": "^4.125.0"
+    "wrangler": "^4.126.0"
   },
   "allowScripts": {
     "esbuild": true,

--- a/workers/files-worker/package.json
+++ b/workers/files-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "files-worker",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/files-worker/wrangler.jsonc.example
+++ b/workers/files-worker/wrangler.jsonc.example
@@ -3,7 +3,7 @@
   "account_id": "ACCOUNT_ID",
   "main": "src/files-worker.ts",
   "workers_dev": false,
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/image-worker/package-lock.json
+++ b/workers/image-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-worker",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-worker",
-      "version": "10.2.4",
+      "version": "10.2.5",
       "devDependencies": {
         "wrangler": "^4.126.0"
       }

--- a/workers/image-worker/package-lock.json
+++ b/workers/image-worker/package-lock.json
@@ -8,7 +8,7 @@
       "name": "image-worker",
       "version": "10.2.4",
       "devDependencies": {
-        "wrangler": "^4.125.0"
+        "wrangler": "^4.126.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260820.1.tgz",
-      "integrity": "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260825.1.tgz",
+      "integrity": "sha512-oHu38dwaUuzAilyTb0QkQ1YxU/kzqzIQybCvQKAhiK1CGtQS9h0MmjIZYogv3g8cFGGY2k+Wxs0wV9hHK8z78g==",
       "cpu": [
         "x64"
       ],
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-ak5zh8YGEjxQQ78bVo7gzU+tcg2fSFxMIjOPZtWk56a/rIYLbGu6ECcliqnYfMUlragg68H0JuVpfdr3BR5Alw==",
       "cpu": [
         "arm64"
       ],
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260820.1.tgz",
-      "integrity": "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260825.1.tgz",
+      "integrity": "sha512-bNQvzz6NemWAwixDRz1fQa5T+E5lS4xpB7A/H/72ULxrjVpHmq8CGFPSbdmRp3dvgBjZTgp7wHdGLISLSVd9Gg==",
       "cpu": [
         "x64"
       ],
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-a5E61YsnNCHHQMnmYsbVXInzeYqFqAMwm/wo16dWW4klXDr6T1bm7u1h5G7ZkxVM7+rtc69oe0yVHjDEqzpYVg==",
       "cpu": [
         "arm64"
       ],
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260820.1.tgz",
-      "integrity": "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260825.1.tgz",
+      "integrity": "sha512-EokzVY2suzRSzeURi2HpHnySR5mo6aF5V1klFIqFOZp2YJyXXTI8AvQgYzhlmGTZY3LNL41jjkUQunOM2OErgQ==",
       "cpu": [
         "x64"
       ],
@@ -1349,16 +1349,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "5.20260820.0-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260820.0-alpha.tgz",
-      "integrity": "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ==",
+      "version": "5.20260825.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260825.0-alpha.tgz",
+      "integrity": "sha512-ZwlF6LuX43ilx9EwMRDKHenoGXiNdcKSyGx5aPaJhuozujVZasb2lRR7t3ojJZSnVzwDPsBBYCu8lLnc+/KIgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
         "undici": "7.29.0",
-        "workerd": "1.20260820.1",
+        "workerd": "1.20260825.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260820.1.tgz",
-      "integrity": "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260825.1.tgz",
+      "integrity": "sha512-ccS6TEaaRxgONKawiYGnFYUVGfr2pmN1b7mrNtw0ADVhFaYsEIVoCHnQ4UjhM9EJDzuaNgAWFY82nzVrjWpuOA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1493,17 +1493,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260820.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260820.1",
-        "@cloudflare/workerd-linux-64": "1.20260820.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260820.1",
-        "@cloudflare/workerd-windows-64": "1.20260820.1"
+        "@cloudflare/workerd-darwin-64": "1.20260825.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260825.1",
+        "@cloudflare/workerd-linux-64": "1.20260825.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260825.1",
+        "@cloudflare/workerd-windows-64": "1.20260825.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.125.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.125.0.tgz",
-      "integrity": "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg==",
+      "version": "4.126.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.126.0.tgz",
+      "integrity": "sha512-glDq/nxaeQwue0XMIeupfwlu2jVxnFs+wjDFT71DQuURN5LsVdCwu0Af/1ep10U5xr1rKPGhHDEDkKG9nxE/dg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1511,10 +1511,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260820.0-alpha",
+        "miniflare": "5.20260825.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260820.1"
+        "workerd": "1.20260825.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -1528,7 +1528,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260820.1"
+        "@cloudflare/workers-types": "^5.20260825.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/workers/image-worker/package.json
+++ b/workers/image-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-worker",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/image-worker/package.json
+++ b/workers/image-worker/package.json
@@ -8,7 +8,7 @@
     "start": "wrangler dev"
   },
   "devDependencies": {
-    "wrangler": "^4.125.0"
+    "wrangler": "^4.126.0"
   },
   "allowScripts": {
     "esbuild": true,

--- a/workers/image-worker/wrangler.jsonc.example
+++ b/workers/image-worker/wrangler.jsonc.example
@@ -3,7 +3,7 @@
   "account_id": "ACCOUNT_ID",
   "main": "src/image-worker.ts",
   "workers_dev": false,
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/workers/lists-worker/package-lock.json
+++ b/workers/lists-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lists-worker",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lists-worker",
-      "version": "10.2.4",
+      "version": "10.2.5",
       "devDependencies": {
         "wrangler": "^4.126.0"
       }

--- a/workers/lists-worker/package-lock.json
+++ b/workers/lists-worker/package-lock.json
@@ -8,7 +8,7 @@
       "name": "lists-worker",
       "version": "10.2.4",
       "devDependencies": {
-        "wrangler": "^4.125.0"
+        "wrangler": "^4.126.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260820.1.tgz",
-      "integrity": "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260825.1.tgz",
+      "integrity": "sha512-oHu38dwaUuzAilyTb0QkQ1YxU/kzqzIQybCvQKAhiK1CGtQS9h0MmjIZYogv3g8cFGGY2k+Wxs0wV9hHK8z78g==",
       "cpu": [
         "x64"
       ],
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-ak5zh8YGEjxQQ78bVo7gzU+tcg2fSFxMIjOPZtWk56a/rIYLbGu6ECcliqnYfMUlragg68H0JuVpfdr3BR5Alw==",
       "cpu": [
         "arm64"
       ],
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260820.1.tgz",
-      "integrity": "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260825.1.tgz",
+      "integrity": "sha512-bNQvzz6NemWAwixDRz1fQa5T+E5lS4xpB7A/H/72ULxrjVpHmq8CGFPSbdmRp3dvgBjZTgp7wHdGLISLSVd9Gg==",
       "cpu": [
         "x64"
       ],
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-a5E61YsnNCHHQMnmYsbVXInzeYqFqAMwm/wo16dWW4klXDr6T1bm7u1h5G7ZkxVM7+rtc69oe0yVHjDEqzpYVg==",
       "cpu": [
         "arm64"
       ],
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260820.1.tgz",
-      "integrity": "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260825.1.tgz",
+      "integrity": "sha512-EokzVY2suzRSzeURi2HpHnySR5mo6aF5V1klFIqFOZp2YJyXXTI8AvQgYzhlmGTZY3LNL41jjkUQunOM2OErgQ==",
       "cpu": [
         "x64"
       ],
@@ -1349,16 +1349,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "5.20260820.0-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260820.0-alpha.tgz",
-      "integrity": "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ==",
+      "version": "5.20260825.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260825.0-alpha.tgz",
+      "integrity": "sha512-ZwlF6LuX43ilx9EwMRDKHenoGXiNdcKSyGx5aPaJhuozujVZasb2lRR7t3ojJZSnVzwDPsBBYCu8lLnc+/KIgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
         "undici": "7.29.0",
-        "workerd": "1.20260820.1",
+        "workerd": "1.20260825.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260820.1.tgz",
-      "integrity": "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260825.1.tgz",
+      "integrity": "sha512-ccS6TEaaRxgONKawiYGnFYUVGfr2pmN1b7mrNtw0ADVhFaYsEIVoCHnQ4UjhM9EJDzuaNgAWFY82nzVrjWpuOA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1493,17 +1493,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260820.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260820.1",
-        "@cloudflare/workerd-linux-64": "1.20260820.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260820.1",
-        "@cloudflare/workerd-windows-64": "1.20260820.1"
+        "@cloudflare/workerd-darwin-64": "1.20260825.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260825.1",
+        "@cloudflare/workerd-linux-64": "1.20260825.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260825.1",
+        "@cloudflare/workerd-windows-64": "1.20260825.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.125.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.125.0.tgz",
-      "integrity": "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg==",
+      "version": "4.126.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.126.0.tgz",
+      "integrity": "sha512-glDq/nxaeQwue0XMIeupfwlu2jVxnFs+wjDFT71DQuURN5LsVdCwu0Af/1ep10U5xr1rKPGhHDEDkKG9nxE/dg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1511,10 +1511,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260820.0-alpha",
+        "miniflare": "5.20260825.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260820.1"
+        "workerd": "1.20260825.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -1528,7 +1528,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260820.1"
+        "@cloudflare/workers-types": "^5.20260825.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/workers/lists-worker/package.json
+++ b/workers/lists-worker/package.json
@@ -8,7 +8,7 @@
     "start": "wrangler dev"
   },
   "devDependencies": {
-    "wrangler": "^4.125.0"
+    "wrangler": "^4.126.0"
   },
   "allowScripts": {
     "esbuild": true,

--- a/workers/lists-worker/package.json
+++ b/workers/lists-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lists-worker",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/lists-worker/wrangler.jsonc.example
+++ b/workers/lists-worker/wrangler.jsonc.example
@@ -3,7 +3,7 @@
   "account_id": "ACCOUNT_ID",
   "main": "src/lists-worker.ts",
   "workers_dev": false,
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": [
     "nodejs_compat"
   ],

--- a/workers/pdf-worker/package-lock.json
+++ b/workers/pdf-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdf-worker",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-worker",
-      "version": "10.2.4",
+      "version": "10.2.5",
       "devDependencies": {
         "wrangler": "^4.126.0"
       }

--- a/workers/pdf-worker/package-lock.json
+++ b/workers/pdf-worker/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pdf-worker",
       "version": "10.2.4",
       "devDependencies": {
-        "wrangler": "^4.125.0"
+        "wrangler": "^4.126.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260820.1.tgz",
-      "integrity": "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260825.1.tgz",
+      "integrity": "sha512-oHu38dwaUuzAilyTb0QkQ1YxU/kzqzIQybCvQKAhiK1CGtQS9h0MmjIZYogv3g8cFGGY2k+Wxs0wV9hHK8z78g==",
       "cpu": [
         "x64"
       ],
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-ak5zh8YGEjxQQ78bVo7gzU+tcg2fSFxMIjOPZtWk56a/rIYLbGu6ECcliqnYfMUlragg68H0JuVpfdr3BR5Alw==",
       "cpu": [
         "arm64"
       ],
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260820.1.tgz",
-      "integrity": "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260825.1.tgz",
+      "integrity": "sha512-bNQvzz6NemWAwixDRz1fQa5T+E5lS4xpB7A/H/72ULxrjVpHmq8CGFPSbdmRp3dvgBjZTgp7wHdGLISLSVd9Gg==",
       "cpu": [
         "x64"
       ],
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-a5E61YsnNCHHQMnmYsbVXInzeYqFqAMwm/wo16dWW4klXDr6T1bm7u1h5G7ZkxVM7+rtc69oe0yVHjDEqzpYVg==",
       "cpu": [
         "arm64"
       ],
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260820.1.tgz",
-      "integrity": "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260825.1.tgz",
+      "integrity": "sha512-EokzVY2suzRSzeURi2HpHnySR5mo6aF5V1klFIqFOZp2YJyXXTI8AvQgYzhlmGTZY3LNL41jjkUQunOM2OErgQ==",
       "cpu": [
         "x64"
       ],
@@ -1349,16 +1349,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "5.20260820.0-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260820.0-alpha.tgz",
-      "integrity": "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ==",
+      "version": "5.20260825.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260825.0-alpha.tgz",
+      "integrity": "sha512-ZwlF6LuX43ilx9EwMRDKHenoGXiNdcKSyGx5aPaJhuozujVZasb2lRR7t3ojJZSnVzwDPsBBYCu8lLnc+/KIgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
         "undici": "7.29.0",
-        "workerd": "1.20260820.1",
+        "workerd": "1.20260825.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260820.1.tgz",
-      "integrity": "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260825.1.tgz",
+      "integrity": "sha512-ccS6TEaaRxgONKawiYGnFYUVGfr2pmN1b7mrNtw0ADVhFaYsEIVoCHnQ4UjhM9EJDzuaNgAWFY82nzVrjWpuOA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1493,17 +1493,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260820.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260820.1",
-        "@cloudflare/workerd-linux-64": "1.20260820.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260820.1",
-        "@cloudflare/workerd-windows-64": "1.20260820.1"
+        "@cloudflare/workerd-darwin-64": "1.20260825.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260825.1",
+        "@cloudflare/workerd-linux-64": "1.20260825.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260825.1",
+        "@cloudflare/workerd-windows-64": "1.20260825.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.125.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.125.0.tgz",
-      "integrity": "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg==",
+      "version": "4.126.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.126.0.tgz",
+      "integrity": "sha512-glDq/nxaeQwue0XMIeupfwlu2jVxnFs+wjDFT71DQuURN5LsVdCwu0Af/1ep10U5xr1rKPGhHDEDkKG9nxE/dg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1511,10 +1511,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260820.0-alpha",
+        "miniflare": "5.20260825.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260820.1"
+        "workerd": "1.20260825.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -1528,7 +1528,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260820.1"
+        "@cloudflare/workers-types": "^5.20260825.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/workers/pdf-worker/package.json
+++ b/workers/pdf-worker/package.json
@@ -9,7 +9,7 @@
     "start": "wrangler dev"
   },
   "devDependencies": {
-    "wrangler": "^4.125.0"
+    "wrangler": "^4.126.0"
   },
   "allowScripts": {
     "esbuild": true,

--- a/workers/pdf-worker/package.json
+++ b/workers/pdf-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-worker",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "private": true,
   "scripts": {
     "generate:assets": "node scripts/generate-assets.js",

--- a/workers/pdf-worker/wrangler.jsonc.example
+++ b/workers/pdf-worker/wrangler.jsonc.example
@@ -3,7 +3,7 @@
   "account_id": "ACCOUNT_ID",
   "main": "src/pdf-worker.ts",
   "workers_dev": false,
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": [
     "nodejs_compat"
   ],

--- a/workers/user-worker/package-lock.json
+++ b/workers/user-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "user-worker",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "user-worker",
-      "version": "10.2.4",
+      "version": "10.2.5",
       "devDependencies": {
         "wrangler": "^4.126.0"
       }

--- a/workers/user-worker/package-lock.json
+++ b/workers/user-worker/package-lock.json
@@ -8,7 +8,7 @@
       "name": "user-worker",
       "version": "10.2.4",
       "devDependencies": {
-        "wrangler": "^4.125.0"
+        "wrangler": "^4.126.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260820.1.tgz",
-      "integrity": "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260825.1.tgz",
+      "integrity": "sha512-oHu38dwaUuzAilyTb0QkQ1YxU/kzqzIQybCvQKAhiK1CGtQS9h0MmjIZYogv3g8cFGGY2k+Wxs0wV9hHK8z78g==",
       "cpu": [
         "x64"
       ],
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-ak5zh8YGEjxQQ78bVo7gzU+tcg2fSFxMIjOPZtWk56a/rIYLbGu6ECcliqnYfMUlragg68H0JuVpfdr3BR5Alw==",
       "cpu": [
         "arm64"
       ],
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260820.1.tgz",
-      "integrity": "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260825.1.tgz",
+      "integrity": "sha512-bNQvzz6NemWAwixDRz1fQa5T+E5lS4xpB7A/H/72ULxrjVpHmq8CGFPSbdmRp3dvgBjZTgp7wHdGLISLSVd9Gg==",
       "cpu": [
         "x64"
       ],
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260820.1.tgz",
-      "integrity": "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-a5E61YsnNCHHQMnmYsbVXInzeYqFqAMwm/wo16dWW4klXDr6T1bm7u1h5G7ZkxVM7+rtc69oe0yVHjDEqzpYVg==",
       "cpu": [
         "arm64"
       ],
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260820.1.tgz",
-      "integrity": "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260825.1.tgz",
+      "integrity": "sha512-EokzVY2suzRSzeURi2HpHnySR5mo6aF5V1klFIqFOZp2YJyXXTI8AvQgYzhlmGTZY3LNL41jjkUQunOM2OErgQ==",
       "cpu": [
         "x64"
       ],
@@ -1349,16 +1349,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "5.20260820.0-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260820.0-alpha.tgz",
-      "integrity": "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ==",
+      "version": "5.20260825.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260825.0-alpha.tgz",
+      "integrity": "sha512-ZwlF6LuX43ilx9EwMRDKHenoGXiNdcKSyGx5aPaJhuozujVZasb2lRR7t3ojJZSnVzwDPsBBYCu8lLnc+/KIgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
         "undici": "7.29.0",
-        "workerd": "1.20260820.1",
+        "workerd": "1.20260825.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260820.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260820.1.tgz",
-      "integrity": "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w==",
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260825.1.tgz",
+      "integrity": "sha512-ccS6TEaaRxgONKawiYGnFYUVGfr2pmN1b7mrNtw0ADVhFaYsEIVoCHnQ4UjhM9EJDzuaNgAWFY82nzVrjWpuOA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1493,17 +1493,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260820.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260820.1",
-        "@cloudflare/workerd-linux-64": "1.20260820.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260820.1",
-        "@cloudflare/workerd-windows-64": "1.20260820.1"
+        "@cloudflare/workerd-darwin-64": "1.20260825.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260825.1",
+        "@cloudflare/workerd-linux-64": "1.20260825.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260825.1",
+        "@cloudflare/workerd-windows-64": "1.20260825.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.125.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.125.0.tgz",
-      "integrity": "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg==",
+      "version": "4.126.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.126.0.tgz",
+      "integrity": "sha512-glDq/nxaeQwue0XMIeupfwlu2jVxnFs+wjDFT71DQuURN5LsVdCwu0Af/1ep10U5xr1rKPGhHDEDkKG9nxE/dg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1511,10 +1511,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260820.0-alpha",
+        "miniflare": "5.20260825.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260820.1"
+        "workerd": "1.20260825.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -1528,7 +1528,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260820.1"
+        "@cloudflare/workers-types": "^5.20260825.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/workers/user-worker/package.json
+++ b/workers/user-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-worker",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/workers/user-worker/package.json
+++ b/workers/user-worker/package.json
@@ -8,7 +8,7 @@
     "start": "wrangler dev"
   },
   "devDependencies": {
-    "wrangler": "^4.125.0"
+    "wrangler": "^4.126.0"
   },
   "allowScripts": {
     "esbuild": true,

--- a/workers/user-worker/wrangler.jsonc.example
+++ b/workers/user-worker/wrangler.jsonc.example
@@ -3,7 +3,7 @@
   "account_id": "ACCOUNT_ID",
   "main": "src/user-worker.ts",
   "workers_dev": false,
-  "compatibility_date": "2026-08-20",
+  "compatibility_date": "2026-08-25",
   "compatibility_flags": [
     "nodejs_compat"
   ], 

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -1,6 +1,6 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "PAGES_PROJECT_NAME"
-compatibility_date = "2026-08-20"
+compatibility_date = "2026-08-25"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./build/client"
 


### PR DESCRIPTION
This pull request delivers the v10.2.5 patch release for the Striae platform, focusing on security hardening and dependency maintenance. The most significant update is the migration of all future self-generated RSA key pairs from a 2048-bit to a 3072-bit modulus, improving cryptographic strength for key generation and rotation. Additionally, several dependencies are updated across the root project and all workers, along with compatibility date refreshes. No changes affect existing deployed keys or API/storage contracts.

**Security Improvements:**

* Migrated all self-generated RSA key-pair routines (manifest signing, export encryption, data-at-rest encryption, user KV encryption) to use a shared `RSA_KEY_MODULUS_LENGTH=3072` constant in `scripts/deploy-config/modules/keys.sh`, replacing the previous hardcoded 2048-bit modulus. This change applies only to newly generated keys; existing keys remain valid until rotated. [[1]](diffhunk://#diff-6a433e44d37516c5cd767337221cc8a7e631a8d71fa7ba5fb98416ab645ad9d7R6-R9) [[2]](diffhunk://#diff-6a433e44d37516c5cd767337221cc8a7e631a8d71fa7ba5fb98416ab645ad9d7L80-R84) [[3]](diffhunk://#diff-6a433e44d37516c5cd767337221cc8a7e631a8d71fa7ba5fb98416ab645ad9d7L165-R169) [[4]](diffhunk://#diff-6a433e44d37516c5cd767337221cc8a7e631a8d71fa7ba5fb98416ab645ad9d7L250-R254) [[5]](diffhunk://#diff-6a433e44d37516c5cd767337221cc8a7e631a8d71fa7ba5fb98416ab645ad9d7L282-R286)

**Dependency and Compatibility Maintenance:**

* Updated root dependencies in `package.json`: bumped `@cloudflare/vite-plugin` to `1.54.0`, `@cloudflare/workers-types` to `5.20260825.1`, and `wrangler` to `4.126.0`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L148-R150) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L171-R171)
* Updated all worker packages (e.g., `audit-worker`) to use `wrangler@4.126.0` and refreshed related lockfiles and sub-dependencies, ensuring consistency and compatibility. [[1]](diffhunk://#diff-d16fb6b09f684160054b5c0e353e35f63f00651bc94bcbcaf521437dfccd9fc9L3-R11) [[2]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L3-R11) [[3]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L41-R43) [[4]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L58-R60) [[5]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L75-R77) [[6]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L92-R94) [[7]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L109-R111) [[8]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L1352-R1361) [[9]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L1483-R1485) [[10]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L1496-R1517) [[11]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L1531-R1531)
* Updated `compatibility_date` to `2026-08-25` in all relevant `wrangler` config examples.

**Documentation and Release Tracking:**

* Added a new changelog entry for v10.2.5 in `.github/README.md` and created detailed release notes in `.github/release-notes/RELEASE_NOTES_v10.2.5.md`, summarizing the RSA-3072 migration and dependency updates. [[1]](diffhunk://#diff-438478e7713ffdb96be895cd2cba03144f30c04f1442ae246acdeb2f1c13efd5R31-R35) [[2]](diffhunk://#diff-b6085c9dfa4bcaa3d262de0c84009ec31833d134ebd8c9fb230fa96d5652e187R1-R36)
* Updated `.github/SECURITY.md` and all affected `package.json` files to reflect version `10.2.5`. [[1]](diffhunk://#diff-ac3050733d58345444c27d37c6247ef260ad992bcb02782feea43fb580106079L7-R7) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[3]](diffhunk://#diff-d16fb6b09f684160054b5c0e353e35f63f00651bc94bcbcaf521437dfccd9fc9L3-R11) [[4]](diffhunk://#diff-dbc0318f52170b314027eae990bfb736330a814c7762ee22c9dfc85b80ae0078L3-R11)

These changes collectively strengthen the platform’s cryptographic posture and ensure up-to-date dependencies across the codebase.